### PR TITLE
Fix unique values cmdopt

### DIFF
--- a/tsv-summarize/src/tsv-summarize.d
+++ b/tsv-summarize/src/tsv-summarize.d
@@ -180,12 +180,12 @@ struct TsvSummarizeOptions {
                 "var",                "n[,n...][:STR]  Variance. (Sample variance, numeric fields only).", &operatorOptionHandler!VarianceOperator,
                 "stdev",              "n[,n...][:STR]  Standard deviation. (Sample st.dev, numeric fields only).", &operatorOptionHandler!StDevOperator,
                 "mode",               "n[,n...][:STR]  Mode. The most frequent value. (Reads all unique values into memory.)", &operatorOptionHandler!ModeOperator,
-                "mode-count",         "n[,n...][:STR]  Count of the most frequent value. (Reads all unique values into memory.)", &operatorOptionHandler!ModeOperator,
+                "mode-count",         "n[,n...][:STR]  Count of the most frequent value. (Reads all unique values into memory.)", &operatorOptionHandler!ModeCountOperator,
                 "unique-count",       "n[,n...][:STR]  Number of unique values. (Reads all unique values into memory.)", &operatorOptionHandler!UniqueCountOperator,
                 "missing-count",      "n[,n...][:STR]  Number of missing (empty) fields. Not affected by '--x|exclude-missing' or '--r|replace-missing'.", &operatorOptionHandler!MissingCountOperator,
-                "not-missing-count",  "n[,n...][:STR]  Number of filled (non-empty) fields. Not affected by '--r|replace-missing'.", &operatorOptionHandler!MissingCountOperator,
+                "not-missing-count",  "n[,n...][:STR]  Number of filled (non-empty) fields. Not affected by '--r|replace-missing'.", &operatorOptionHandler!NotMissingCountOperator,
                 "values",             "n[,n...][:STR]  All the values, separated by --v|values-delimiter. (Reads all values into memory.)", &operatorOptionHandler!ValuesOperator,
-                "unique-values",      "n[,n...][:STR]  All the unique values, separated by --v|values-delimiter. (Reads all unique values into memory.)", &operatorOptionHandler!ValuesOperator,
+                "unique-values",      "n[,n...][:STR]  All the unique values, separated by --v|values-delimiter. (Reads all unique values into memory.)", &operatorOptionHandler!UniqueValuesOperator,
                 );
 
             if (r.helpWanted)

--- a/tsv-summarize/tests/gold/basic_tests_1.txt
+++ b/tsv-summarize/tests/gold/basic_tests_1.txt
@@ -1,6 +1,14 @@
 Basic tests set 1
 -----------------
 
+====[tsv-summarize --header --float-precision 2 --retain 1 --first 1 --last 1 --min 3 --max 3 --range 3 --sum 3 --median 3 --mad 3 --var 3 --stdev 3 --mode 1 --mode-count 1 --values 1 --unique-values 1 input_5field_a.tsv]====
+color	color_first	color_last	length_min	length_max	length_range	length_sum	length_median	length_mad	length_var	length_stdev	color_mode	color_mode_count	color_values	color_unique_values
+red	red	green	7.4	16	8.6	78.4	11	3	9.61	3.1	blue	3	red|red|blue|green|blue|blue|green	red|blue|green
+
+====[tsv-summarize --header --missing-count 1 --not-missing-count 1 input_1field_a.tsv]====
+size_unique_count	size_unique_count
+1	5
+
 ====[tsv-summarize --header --count --min 3,4,5 --max 3,4,5 input_5field_a.tsv]====
 count	length_min	width_min	height_min	length_max	width_max	height_max
 7	7.4	1	2	16	6	7

--- a/tsv-summarize/tests/tests.sh
+++ b/tsv-summarize/tests/tests.sh
@@ -30,6 +30,12 @@ basic_tests_1=${odir}/basic_tests_1.txt
 echo "Basic tests set 1" > ${basic_tests_1}
 echo "-----------------" >> ${basic_tests_1}
 
+## One test for each operator. Make sure it is hooked up to the command line args properly
+runtest ${prog} "--header --float-precision 2 --retain 1 --first 1 --last 1 --min 3 --max 3 --range 3 --sum 3 --median 3 --mad 3 --var 3 --stdev 3 --mode 1 --mode-count 1 --values 1 --unique-values 1 input_5field_a.tsv" ${basic_tests_1}
+
+runtest ${prog} "--header --missing-count 1 --not-missing-count 1 input_1field_a.tsv" ${basic_tests_1}
+
+## Functionality tests
 runtest ${prog} "--header --count --min 3,4,5 --max 3,4,5 input_5field_a.tsv" ${basic_tests_1}
 runtest ${prog} "--header --group-by 1 --count --min 3,4,5 --max 3,4,5 input_5field_a.tsv" ${basic_tests_1}
 runtest ${prog} "--header --group-by 1,2 --count --min 3,4,5 --max 3,4,5 input_5field_a.tsv" ${basic_tests_1}


### PR DESCRIPTION
The newest operators were not hooked up to command line options properly. Fixed them up and added tests for this.