### PR TITLE
Add a simple travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false
+os:
+ - linux
+ - osx
+language: d
+d:
+ - ldc
+ - dmd
+script:
+ - make test unittest_flags="-main -unittest" DCOMPILER=$DC


### PR DESCRIPTION
This adds a simple `.travis.yml` that should help you to get started.

More documentation can be found at:

https://docs.travis-ci.com/user/languages/d/

(the other Travis commands are not D-specific) 