### PR TITLE
Add dub build to travis ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,8 @@ d:
  - ldc
  - dmd
 script:
- - make test unittest_flags="-main -unittest" DCOMPILER=$DC
+ - dub run -- --compiler=$DC
+ - make test-nobuild
+ - dub clean
+ - make clean
+ - make test DCOMPILER=$DC


### PR DESCRIPTION
This adds the dub build to travis ci. It builds the executables with dub, then runs the "executable" tests via 'make test-nobuild'. It cleans build artifacts, and then runs the 'make' builds and tests that were already in place.