### PR TITLE
Fields lists and field ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ See the [tsv-filter reference](docs/ToolReference.md#tsv-filter-reference) for d
 
 ### tsv-select
 
-A version of the Unix `cut` utility with the additional ability to re-order the fields. It also helps with header lines by keeping only the header from the first file (`--header` option). The following command writes fields [4, 2, 9] from a pair of files to stdout:
+A version of the Unix `cut` utility with the additional ability to re-order the fields. It also helps with header lines by keeping only the header from the first file (`--header` option). The following command writes fields [4, 2, 9, 10, 11] from a pair of files to stdout:
 ```
-$ tsv-select -f 4,2,9 file1.tsv file2.tsv
+$ tsv-select -f 4,2,9-11 file1.tsv file2.tsv
 ```
 
 Reordering fields and managing headers are useful enhancements over `cut`. However, much of the motivation for writing it was to explore the D programming language and provide a comparison point against other common approaches to this task. Code for `tsv-select` is bit more liberal with comments pointing out D programming constructs than code for the other tools.

--- a/common/src/tsvutil.d
+++ b/common/src/tsvutil.d
@@ -538,6 +538,7 @@ OptionHandlerDelegate makeFieldListOptionHandler(
 
 unittest
 {
+    import std.exception : assertThrown, assertNotThrown;
     import std.getopt;
 
     {
@@ -655,6 +656,39 @@ unittest
         getopt(args,
                "f|fields", fields.makeFieldListOptionHandler!(short, Yes.convertToZeroBasedIndex, Yes.allowFieldNumZero));
         assert(fields == [-1]);
+    }
+
+    {
+        /* Error cases. */
+        size_t[] fields;
+        auto args = ["program", "-f", "0"];
+        assertThrown(getopt(args, "f|fields", fields.makeFieldListOptionHandler));
+
+        args = ["program", "-f", "-1"];
+        assertThrown(getopt(args, "f|fields", fields.makeFieldListOptionHandler));
+
+        args = ["program", "-f", "--fields", "1"];
+        assertThrown(getopt(args, "f|fields", fields.makeFieldListOptionHandler));
+
+        args = ["program", "-f", "a"];
+        assertThrown(getopt(args, "f|fields", fields.makeFieldListOptionHandler));
+
+        args = ["program", "-f", "1.5"];
+        assertThrown(getopt(args, "f|fields", fields.makeFieldListOptionHandler));
+
+        args = ["program", "-f", "2-"];
+        assertThrown(getopt(args, "f|fields", fields.makeFieldListOptionHandler));
+
+        args = ["program", "-f", "3,5,-7"];
+        assertThrown(getopt(args, "f|fields", fields.makeFieldListOptionHandler));
+
+        args = ["program", "-f", "3,5,"];
+        assertThrown(getopt(args, "f|fields", fields.makeFieldListOptionHandler));
+
+        args = ["program", "-f", "-1"];
+        assertThrown(getopt(args,
+                            "f|fields", fields.makeFieldListOptionHandler!(
+                                size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero)));
     }
 }
 

--- a/common/src/tsvutil.d
+++ b/common/src/tsvutil.d
@@ -512,14 +512,30 @@ intended for display. Error conditions include:
 No other behaviors are enforced. Repeated values are accepted. If zero is allowed, other
 field numbers can be entered as well. Additional restrictions need to be applied by the
 caller.
+
+Notes:
+  - The data type determines the max field number that can be entered. Enabling conversion
+    to zero restricts to the signed version of the data type.
+  - Use 'import std.typecons : Yes, No' to use the convertToZeroBasedIndex and
+    allowFieldNumZero template parameters.
 */
+
+/** [Yes|No].convertToZeroBasedIndex parameter controls whether field numbers are
+ *  converted to zero-based indices by makeFieldListOptionHander and parseFieldList.
+ */
+alias ConvertToZeroBasedIndex = Flag!"convertToZeroBasedIndex";
+
+/** [Yes|No].allowFieldNumZero parameter controls whether zero is a valid field. This is
+ *  used by makeFieldListOptionHander and parseFieldList.
+ */
+alias AllowFieldNumZero = Flag!"allowFieldNumZero";
+
+alias OptionHandlerDelegate = void delegate(string option, string value);
 
 /**
 makeFieldListOptionHandler creates a std.getopt option hander for processing field lists
 entered on the command line. A field list is as defined by parseFieldList.
 */
-alias OptionHandlerDelegate = void delegate(string option, string value);
-
 OptionHandlerDelegate makeFieldListOptionHandler(
     T,
     ConvertToZeroBasedIndex convertToZero = No.convertToZeroBasedIndex,
@@ -701,10 +717,6 @@ unittest
 /**
 parseFieldList lazily generates a range of fields numbers from a 'field-list' string.
 */
-
-alias ConvertToZeroBasedIndex = Flag!"convertToZeroBasedIndex";
-alias AllowFieldNumZero = Flag!"allowFieldNumZero";
-
 auto parseFieldList(T = size_t,
                     ConvertToZeroBasedIndex convertToZero = No.convertToZeroBasedIndex,
                     AllowFieldNumZero allowZero = No.allowFieldNumZero)

--- a/docs/ToolReference.md
+++ b/docs/ToolReference.md
@@ -167,7 +167,8 @@ $ tsv-filter --regex '2:aa[0-9]+aa' data.tsv
 $ # Same thing, except the field starts and ends with the two a's.
 $ tsv-filter --regex '2:^aa[0-9]+aa$' data.tsv
 
-$ # Field 2 is a sequence of "word" characters with two or more embedded whitespace sequences
+$ # Field 2 is a sequence of "word" characters with two or more embedded
+$ # whitespace sequences (match against entire field)
 $ tsv-filter --regex '2:^\w+\s+(\w+\s+)+\w+$' data.tsv
 
 $ # Field 2 containing at least one cyrillic character.
@@ -182,7 +183,7 @@ Numeric tests like `--gt` (greater-than) assume field values can be interpreted 
 $ # Ensure field 2 is a number before testing for greater-than 10.
 $ tsv-filter --is-numeric 2 --gt 2:10 data.tsv
 
-$ # Ensure field 2 is a number, not NaN or infinity before testing for greater-than 10.
+$ # Ensure field 2 is a number, not NaN or infinity before greater-than test.
 $ tsv-filter --is-finite 2 --gt 2:10 data.tsv
 ```
 
@@ -547,7 +548,8 @@ number-lines reads from files or standard input and writes each line to standard
 $ # Number lines in a file
 $ number-lines file.tsv
 
-$ # Number lines from multiple files. Treat the first line each file as a header.
+$ # Number lines from multiple files. Treat the first line of each file
+$ # as a header.
 $ number-lines --header data*.tsv
 ```
 

--- a/docs/ToolReference.md
+++ b/docs/ToolReference.md
@@ -190,7 +190,7 @@ The above tests work because `tsv-filter` short-circuits evaluation, only runnin
 
 ## tsv-select reference
 
-**Synopsis:** tsv-select -f n[,n...] [options] [file...]
+**Synopsis:** tsv-select -f <field-list> [options] [file...]
 
 tsv-select reads files or standard input and writes specified fields to standard output in the order listed. Similar to `cut` with the ability to reorder fields.
 

--- a/docs/ToolReference.md
+++ b/docs/ToolReference.md
@@ -268,15 +268,16 @@ Most operators take custom headers in a similarly way, generally following:
 --<operator-name> FIELD[:header]
 ```
 
-Operators can be specified multiple times. They can also take multiple fields (though not when a custom header is specified). Example:
+Operators can be specified multiple times. They can also take multiple fields (though not when a custom header is specified). Examples:
 ```
 --median 2,3,4
+--median 1,5-8
 ```
 
 The quantile operator requires one or more probabilities after the fields:
 ```
---quantile 2:0.25                // Quantile 1 of field 2
---quantile 2,3,4:0.25,0.5,0.75   // Q1, Median, Q3 of fields 2, 3, 4
+--quantile 2:0.25              # Quantile 1 of field 2
+--quantile 2-4:0.25,0.5,0.75   # Q1, Median, Q3 of fields 2, 3, 4
 ```
 
 Summarization operators available are:
@@ -301,7 +302,7 @@ Missing values are not treated specially by default, this can be changed using t
 * `--h|help` - Print help.
 * `--help-verbose` - Print detailed help.
 * `--V|version` - Print version information and exit.
-* `--g|group-by n[,n...]` - Fields to use as key.
+* `--g|group-by <field-list>` - Fields to use as key.
 * `--H|header` - Treat the first line of each file as a header.
 * `--w|write-header` - Write an output header even if there is no input header.
 * `--d|delimiter CHR` - Field delimiter. Default: TAB. (Single byte UTF-8 characters only.)
@@ -313,26 +314,26 @@ Missing values are not treated specially by default, this can be changed using t
 **Operators:**
 * `--count` - Count occurrences of each unique key.
 * `--count-header STR` - Count occurrences of each unique key, use header STR.
-* `--retain n[,n...]` - Retain one copy of the field.
-* `--first n[,n...][:STR]` - First value seen.
-* `--last n[,n...][:STR]`- Last value seen.
-* `--min n[,n...][:STR]` - Min value. (Numeric fields only.)
-* `--max n[,n...][:STR]` - Max value. (Numeric fields only.)
-* `--range n[,n...][:STR]` - Difference between min and max values. (Numeric fields only.)
-* `--sum n[,n...][:STR]` - Sum of the values. (Numeric fields only.)
-* `--mean n[,n...][:STR]` - Mean (average). (Numeric fields only.)
-* `--median n[,n...][:STR]` - Median value. (Numeric fields only. Reads all values into memory.)
-* `--quantile n[,n...]:p[,p...][:STR]` - Quantiles. One or more fields, then one or more 0.0-1.0 probabilities. (Numeric fields only. Reads all values into memory.)
-* `--mad n[,n...][:STR]` - Median absolute deviation from the median. Raw value, not scaled. (Numeric fields only. Reads all values into memory.)
-* `--var n[,n...][:STR]` - Variance. (Sample variance, numeric fields only).
-* `--stdev n[,n...][:STR]` - Standard deviation. (Sample st.dev, numeric fields only).
-* `--mode n[,n...][:STR]` - Mode. The most frequent value. (Reads all unique values into memory.)
-* `--mode-count n[,n...][:STR]` - Count of the most frequent value. (Reads all unique values into memory.)
-* `--unique-count n[,n...][:STR]` - Number of unique values. (Reads all unique values into memory).
-* `--missing-count n[,n...][:STR]` - Number of missing (empty) fields. Not affected by the `--x|exclude-missing` or `--r|replace-missing` options.
-* `--not-missing-count n[,n...][:STR]` - Number of filled (non-empty) fields. Not affected by `--r|replace-missing`.
-* `--values n[,n...][:STR]` - All the values, separated by `--v|values-delimiter`. (Reads all values into memory.)
-* `--unique-values n[,n...][:STR]` - All the unique values, separated by `--v|values-delimiter`. (Reads all unique values into memory.)
+* `--retain <field-list>` - Retain one copy of the field.
+* `--first <field-list>[:STR]` - First value seen.
+* `--last <field-list>[:STR]`- Last value seen.
+* `--min <field-list>[:STR]` - Min value. (Numeric fields only.)
+* `--max <field-list>[:STR]` - Max value. (Numeric fields only.)
+* `--range <field-list>[:STR]` - Difference between min and max values. (Numeric fields only.)
+* `--sum <field-list>[:STR]` - Sum of the values. (Numeric fields only.)
+* `--mean <field-list>[:STR]` - Mean (average). (Numeric fields only.)
+* `--median <field-list>[:STR]` - Median value. (Numeric fields only. Reads all values into memory.)
+* `--quantile <field-list>:p[,p...][:STR]` - Quantiles. One or more fields, then one or more 0.0-1.0 probabilities. (Numeric fields only. Reads all values into memory.)
+* `--mad <field-list>[:STR]` - Median absolute deviation from the median. Raw value, not scaled. (Numeric fields only. Reads all values into memory.)
+* `--var <field-list>[:STR]` - Variance. (Sample variance, numeric fields only).
+* `--stdev <field-list>[:STR]` - Standard deviation. (Sample st.dev, numeric fields only).
+* `--mode <field-list>[:STR]` - Mode. The most frequent value. (Reads all unique values into memory.)
+* `--mode-count <field-list>[:STR]` - Count of the most frequent value. (Reads all unique values into memory.)
+* `--unique-count <field-list>[:STR]` - Number of unique values. (Reads all unique values into memory).
+* `--missing-count <field-list>[:STR]` - Number of missing (empty) fields. Not affected by the `--x|exclude-missing` or `--r|replace-missing` options.
+* `--not-missing-count <field-list>[:STR]` - Number of filled (non-empty) fields. Not affected by `--r|replace-missing`.
+* `--values <field-list>[:STR]` - All the values, separated by `--v|values-delimiter`. (Reads all values into memory.)
+* `--unique-values <field-list>[:STR]` - All the unique values, separated by `--v|values-delimiter`. (Reads all unique values into memory.)
 
 ## tsv-join reference
 

--- a/docs/ToolReference.md
+++ b/docs/ToolReference.md
@@ -23,7 +23,6 @@ Information in this section applies to all the tools.
 ### Specifying options
 
 Multi-letter options are specified with a double dash. Single letter options can be specified with a single dash or double dash. For example:
-
 ```
 $ tsv-select -f 1,2         # Valid
 $ tsv-select --f 1,2        # Valid
@@ -35,9 +34,24 @@ $ tsv-select -fields 1,2    # Invalid.
 
 All tools print help if given the `-h` or `--help` option. Many provide more detail via the `--help-verbose` option.
 
-### Field indices
+### Field numbers and field-lists.
 
-Field indices are one-upped integers, following Unix conventions. Some tools use zero to represent the entire line (`tsv-join`, `tsv-uniq`).
+Field numbers are one-upped integers, following Unix conventions. Some tools use zero to represent the entire line (`tsv-join`, `tsv-uniq`).
+
+In many cases multiple fields can be entered as a "field-list". A field-list is a comma separated list of field numbers or field ranges. For example:
+
+```
+$ tsv-select -f 3          # Field 3
+$ tsv-select -f 3,5        # Fields 3 and 5
+$ tsv-select -f 3-5        # Fields 3, 4, 5
+$ tsv-select -f 1,3-5      # Fields 1, 3, 4, 5
+```
+
+Most tools process or output fields in the order listed, and repeated use is usually fine:
+```
+$ tsv-select -f 5-1       # Fields 5, 4, 3, 2, 1
+$ tsv-select -f 1-3,2,1   # Fields 1, 2, 3, 2, 1
+```
 
 ### UTF-8 input
 
@@ -440,7 +454,7 @@ The alternate to 'uniq' mode is 'equiv-class' identification. In this mode, all 
 * `--help-verbose` - Print detailed help.
 * `--V|version` - Print version information and exit.
 * `--H|header` - Treat the first line of each file as a header.
-* `--f|fields n[,n...]` - Fields to use as the key. Default: 0 (entire line).
+* `--f|fields <field-list>` - Fields to use as the key. Default: 0 (entire line).
 * `--i|ignore-case` - Ignore case when comparing keys.
 * `--e|equiv` - Output equiv class IDs rather than uniq'ing entries.
 * `--equiv-header STR` - Use STR as the equiv-id field header. Applies when using `--header --equiv`. Default: 'equiv_id'.
@@ -460,6 +474,9 @@ $ tsv-unique -f 1 data.tsv
 
 $ # Unique a file based on two fields
 $ tsv-uniq -f 1,2 data.tsv
+
+$ # Unique a file based on the first four fields
+$ tsv-uniq -f 1-4 data.tsv
 
 $ # Output all the lines, generating an ID for each unique entry
 $ tsv-uniq -f 1,2 --equiv data.tsv

--- a/docs/ToolReference.md
+++ b/docs/ToolReference.md
@@ -345,9 +345,9 @@ tsv-join matches input lines against lines from a 'filter' file. The match is ba
 * `--h|help-verbose` - Print detailed help.
 * `--V|version` - Print version information and exit.
 * `--f|filter-file FILE` - (Required) File with records to use as a filter.
-* `--k|key-fields n[,n...]` - Fields to use as join key. Default: 0 (entire line).
-* `--d|data-fields n[,n...]` - Data record fields to use as join key, if different than `--key-fields`.
-* `--a|append-fields n[,n...]` - Filter fields to append to matched records.
+* `--k|key-fields <field-list>` - Fields to use as join key. Default: 0 (entire line).
+* `--d|data-fields <field-list>` - Data record fields to use as join key, if different than `--key-fields`.
+* `--a|append-fields <field-list>` - Filter fields to append to matched records.
 * `--H|header` - Treat the first line of each file as a header.
 * `--p|prefix STR` - String to use as a prefix for `--append-fields` when writing a header line.
 * `--w|write-all STR` - Output all data records. STR is the `--append-fields` value when writing unmatched records. This is an outer join.
@@ -376,9 +376,9 @@ Same as previous, except use field 4 & 5 from the data files.
 $ tsv-join -f filter.tsv --key-fields 2,3 --data-fields 4,5 data1.tsv data2.tsv data3.tsv
 ```
 
-Append a field from the filter file to matched records.
+Append fields from the filter file to matched records.
 ```
-$ tsv-join -f filter.tsv --key-fields 1 --append-fields 2 data.tsv
+$ tsv-join -f filter.tsv --key-fields 1 --append-fields 2-5 data.tsv
 ```
 
 Write out all records from the data file, but when there is no match, write the 'append fields' as NULL. This is an outer join.

--- a/docs/ToolReference.md
+++ b/docs/ToolReference.md
@@ -192,13 +192,15 @@ The above tests work because `tsv-filter` short-circuits evaluation, only runnin
 
 **Synopsis:** tsv-select -f n[,n...] [options] [file...]
 
-tsv-select reads files or standard input and writes specified fields to standard output in the order listed. Similar to `cut` with the ability to reorder fields. Fields can be listed more than once, and fields not listed can be output using the `--rest` option. When working with multiple files, the `--header` option can be used to retain only the header from the first file.
+tsv-select reads files or standard input and writes specified fields to standard output in the order listed. Similar to `cut` with the ability to reorder fields.
+
+Fields numbers start with one. They are comma separated, and ranges can be used. Fields can be listed more than once, and fields not listed can be output using the `--rest` option. When working with multiple files, the `--header` option can be used to retain only the header from the first file.
 
 **Options:**
 * `--h|help` - Print help.
 * `--V|version` - Print version information and exit.
-* `--H|header` - Treat the first line of each file as a header. 
-* `--f|fields n[,n...]` - (Required) Fields to extract. Fields are output in the order listed.
+* `--H|header` - Treat the first line of each file as a header.
+* `--f|fields <field-list>` - (Required) Fields to extract. Fields are output in the order listed.
 * `--r|rest none|first|last` - Location for remaining fields. Default: none
 * `--d|delimiter CHR` - Character to use as field delimiter. Default: TAB. (Single byte UTF-8 characters only.)
 
@@ -212,6 +214,19 @@ $ tsv-select -f 1 --rest first data.tsv
 
 $ # Move fields 7 and 3 to the start of the line
 $ tsv-select -f 7,3 --rest last data.tsv
+
+$ # Output a range of fields
+$ tsv-select -f 3-30 data.tsv
+
+$ # Output fields in reverse order
+$ tsv-select -f 30-3 data.tsv
+
+$ # Multiple files with header lines. Keep only one header.
+$ tsv-select data*.tsv -H --fields 1,2,4-7,14
+
+$ # Files using comma as the separator ('simple csv')
+$ # (Note: Does not handle CSV escapes.)
+$ tsv-select -d , --fields 5,1,2 data.csv
 ```
 ## tsv-summarize reference
 
@@ -477,7 +492,7 @@ Each run produces a different randomization. This can be changed using `--s|stat
 * `--v|seed-value NUM` - Sets the initial random seed. Use a non-zero, 32 bit positive integer. Zero is a no-op.
 * `--d|delimiter CHR` - Field delimiter.
 * `--h|help` - This help information.
- 
+
 ## csv2tsv reference
 
 **Synopsis:** csv2tsv [options] [file...]

--- a/tsv-join/tests/gold/basic_tests_1.txt
+++ b/tsv-join/tests/gold/basic_tests_1.txt
@@ -515,6 +515,36 @@ f1	f2	f3	f4	f5	i1_f3	i1_f2	i1_f4
 26	bbb	ZZZ	21	28	ZZZ	bbb	21
 31	 	 	sp-sp	2020b	 	 	sp-sp
 
+====[tsv-join --header -f input1.tsv -k 2 -a 3-2,4 --allow-duplicate-keys -p i1_ input2.tsv]====
+f1	f2	f3	f4	f5	i1_f3	i1_f2	i1_f4
+1	ggg	UUU	101b	15b	CCC	ggg	5734
+2	bbb	ZZZ	21	28	ZZZ	bbb	21
+3	nnn	GGG	336b	3b	GGG	nnn	336
+4	vvv	VVV	43b	403b	VVV	vvv	43
+5	ggg	CCC	5734b	52b	CCC	ggg	5734
+6	ddd	ZZZ	65b	602b	ZZZ	ddd	65
+7	ßßß	SSS	7b	771b	SSS	ßßß	 7
+8	vv	v	85b	832b	v	vv	85
+9	v	vv	97	91	vv	v	97
+10	GGG	nnn	101	102	nnn	GGG	101
+11	v12	PPP	1123b	1167b	PPP	v12	1123
+12	àbc	P	1209b	1234b	P	àbc	1209
+13	ÀSSC		1367b	1331b		ÀSSC	1367
+14	-1	1	1489b	1421b	1	-1	1489
+15		B	1522b	1567b			1634
+16			1634b	1602b			1634
+17	0	X	1721b	1703	X	0	1721
+18	a g  ß	Y	1845b	1801b	Y	a g  ß	1845
+19	%tg-0	Z	1931b	1956b	Z	%tg-0	1931
+20	bbb	ZZZ	21	28	ZZZ	bbb	21
+21	bbb	ZZZ	21	28	ZZZ	bbb	21
+22	ddd	ZZZ	65b	602b	ZZZ	ddd	65
+23	v12	PPP	1123b	1167b	PPP	v12	1123
+24	ÀSSC		1367b	1331b		ÀSSC	1367
+25	0	X	1721b	1703	X	0	1721
+26	bbb	ZZZ	21	28	ZZZ	bbb	21
+31	 	 	sp-sp	2020b	 	 	sp-sp
+
 ====[tsv-join --header -f input1.tsv -k 2 -a 1,2,3,4,5 --allow-duplicate-keys -p i1_ input2.tsv]====
 f1	f2	f3	f4	f5	i1_f1	i1_f2	i1_f3	i1_f4	i1_f5
 1	ggg	UUU	101b	15b	5	ggg	CCC	5734	52
@@ -545,7 +575,67 @@ f1	f2	f3	f4	f5	i1_f1	i1_f2	i1_f3	i1_f4	i1_f5
 26	bbb	ZZZ	21	28	2	bbb	ZZZ	21	28
 31	 	 	sp-sp	2020b	20	 	 	sp-sp	2020
 
+====[tsv-join --header -f input1.tsv -k 2 -a 1-5 --allow-duplicate-keys -p i1_ input2.tsv]====
+f1	f2	f3	f4	f5	i1_f1	i1_f2	i1_f3	i1_f4	i1_f5
+1	ggg	UUU	101b	15b	5	ggg	CCC	5734	52
+2	bbb	ZZZ	21	28	2	bbb	ZZZ	21	28
+3	nnn	GGG	336b	3b	3	nnn	GGG	336	 3
+4	vvv	VVV	43b	403b	4	vvv	VVV	43	403
+5	ggg	CCC	5734b	52b	5	ggg	CCC	5734	52
+6	ddd	ZZZ	65b	602b	6	ddd	ZZZ	65	602
+7	ßßß	SSS	7b	771b	7	ßßß	SSS	 7	771
+8	vv	v	85b	832b	8	vv	v	85	832
+9	v	vv	97	91	9	v	vv	97	91
+10	GGG	nnn	101	102	10	GGG	nnn	101	102
+11	v12	PPP	1123b	1167b	11	v12	PPP	1123	1167
+12	àbc	P	1209b	1234b	12	àbc	P	1209	1234
+13	ÀSSC		1367b	1331b	13	ÀSSC		1367	1331
+14	-1	1	1489b	1421b	14	-1	1	1489	1421
+15		B	1522b	1567b	16			1634	1602
+16			1634b	1602b	16			1634	1602
+17	0	X	1721b	1703	17	0	X	1721	1703
+18	a g  ß	Y	1845b	1801b	18	a g  ß	Y	1845	1801
+19	%tg-0	Z	1931b	1956b	19	%tg-0	Z	1931	1956
+20	bbb	ZZZ	21	28	2	bbb	ZZZ	21	28
+21	bbb	ZZZ	21	28	2	bbb	ZZZ	21	28
+22	ddd	ZZZ	65b	602b	6	ddd	ZZZ	65	602
+23	v12	PPP	1123b	1167b	11	v12	PPP	1123	1167
+24	ÀSSC		1367b	1331b	13	ÀSSC		1367	1331
+25	0	X	1721b	1703	17	0	X	1721	1703
+26	bbb	ZZZ	21	28	2	bbb	ZZZ	21	28
+31	 	 	sp-sp	2020b	20	 	 	sp-sp	2020
+
 ====[tsv-join --header -f input1.tsv -k 2 -a 5,4,3,2,1 --allow-duplicate-keys -p i1_ input2.tsv]====
+f1	f2	f3	f4	f5	i1_f5	i1_f4	i1_f3	i1_f2	i1_f1
+1	ggg	UUU	101b	15b	52	5734	CCC	ggg	5
+2	bbb	ZZZ	21	28	28	21	ZZZ	bbb	2
+3	nnn	GGG	336b	3b	 3	336	GGG	nnn	3
+4	vvv	VVV	43b	403b	403	43	VVV	vvv	4
+5	ggg	CCC	5734b	52b	52	5734	CCC	ggg	5
+6	ddd	ZZZ	65b	602b	602	65	ZZZ	ddd	6
+7	ßßß	SSS	7b	771b	771	 7	SSS	ßßß	7
+8	vv	v	85b	832b	832	85	v	vv	8
+9	v	vv	97	91	91	97	vv	v	9
+10	GGG	nnn	101	102	102	101	nnn	GGG	10
+11	v12	PPP	1123b	1167b	1167	1123	PPP	v12	11
+12	àbc	P	1209b	1234b	1234	1209	P	àbc	12
+13	ÀSSC		1367b	1331b	1331	1367		ÀSSC	13
+14	-1	1	1489b	1421b	1421	1489	1	-1	14
+15		B	1522b	1567b	1602	1634			16
+16			1634b	1602b	1602	1634			16
+17	0	X	1721b	1703	1703	1721	X	0	17
+18	a g  ß	Y	1845b	1801b	1801	1845	Y	a g  ß	18
+19	%tg-0	Z	1931b	1956b	1956	1931	Z	%tg-0	19
+20	bbb	ZZZ	21	28	28	21	ZZZ	bbb	2
+21	bbb	ZZZ	21	28	28	21	ZZZ	bbb	2
+22	ddd	ZZZ	65b	602b	602	65	ZZZ	ddd	6
+23	v12	PPP	1123b	1167b	1167	1123	PPP	v12	11
+24	ÀSSC		1367b	1331b	1331	1367		ÀSSC	13
+25	0	X	1721b	1703	1703	1721	X	0	17
+26	bbb	ZZZ	21	28	28	21	ZZZ	bbb	2
+31	 	 	sp-sp	2020b	2020	sp-sp	 	 	20
+
+====[tsv-join --header -f input1.tsv -k 2 -a 5-1 --allow-duplicate-keys -p i1_ input2.tsv]====
 f1	f2	f3	f4	f5	i1_f5	i1_f4	i1_f3	i1_f2	i1_f1
 1	ggg	UUU	101b	15b	52	5734	CCC	ggg	5
 2	bbb	ZZZ	21	28	28	21	ZZZ	bbb	2
@@ -659,6 +749,36 @@ f1	f2	f3	f4	f5
 26	bbb	ZZZ	21	28
 31	 	 	sp-sp	2020b
 
+====[tsv-join --header -f input1.tsv -k 3-2 -d 3-2 input2.tsv]====
+f1	f2	f3	f4	f5
+1	ggg	UUU	101b	15b
+2	bbb	ZZZ	21	28
+3	nnn	GGG	336b	3b
+4	vvv	VVV	43b	403b
+5	ggg	CCC	5734b	52b
+6	ddd	ZZZ	65b	602b
+7	ßßß	SSS	7b	771b
+8	vv	v	85b	832b
+9	v	vv	97	91
+10	GGG	nnn	101	102
+11	v12	PPP	1123b	1167b
+12	àbc	P	1209b	1234b
+13	ÀSSC		1367b	1331b
+14	-1	1	1489b	1421b
+15		B	1522b	1567b
+16			1634b	1602b
+17	0	X	1721b	1703
+18	a g  ß	Y	1845b	1801b
+19	%tg-0	Z	1931b	1956b
+20	bbb	ZZZ	21	28
+21	bbb	ZZZ	21	28
+22	ddd	ZZZ	65b	602b
+23	v12	PPP	1123b	1167b
+24	ÀSSC		1367b	1331b
+25	0	X	1721b	1703
+26	bbb	ZZZ	21	28
+31	 	 	sp-sp	2020b
+
 ====[tsv-join --header -f input1.tsv -k 3,2 input2.tsv]====
 f1	f2	f3	f4	f5
 1	ggg	UUU	101b	15b
@@ -719,6 +839,17 @@ f1	f2	f3	f4	f5
 25	0	X	1721b	1703
 26	bbb	ZZZ	21	28
 
+====[tsv-join --header -f input1.tsv -k 5,2-3 input2.tsv]====
+f1	f2	f3	f4	f5
+2	bbb	ZZZ	21	28
+9	v	vv	97	91
+10	GGG	nnn	101	102
+17	0	X	1721b	1703
+20	bbb	ZZZ	21	28
+21	bbb	ZZZ	21	28
+25	0	X	1721b	1703
+26	bbb	ZZZ	21	28
+
 ====[tsv-join --header -f input1.tsv -k 2,3 -e input2.tsv]====
 f1	f2	f3	f4	f5
 27	xa	gg	44	45
@@ -736,6 +867,14 @@ f1	f2	f3	f4	f5
 32	xe	gk	48	49
 
 ====[tsv-join --header -f input1.tsv -k 3,2 -d 3,2 -e input2.tsv]====
+f1	f2	f3	f4	f5
+27	xa	gg	44	45
+28	xb	gh	45	46
+29	xc	gi	46	47
+30	xd	gj	47	48
+32	xe	gk	48	49
+
+====[tsv-join --header -f input1.tsv -k 3-2 -d 3-2 -e input2.tsv]====
 f1	f2	f3	f4	f5
 27	xa	gg	44	45
 28	xb	gh	45	46
@@ -774,6 +913,36 @@ f1	f2	f3	f4	f5	f4
 31	 	 	sp-sp	2020b	sp-sp
 
 ====[tsv-join --header -f input1.tsv -k 2,3 -a 4,5 input2.tsv]====
+f1	f2	f3	f4	f5	f4	f5
+1	ggg	UUU	101b	15b	101	15
+2	bbb	ZZZ	21	28	21	28
+3	nnn	GGG	336b	3b	336	 3
+4	vvv	VVV	43b	403b	43	403
+5	ggg	CCC	5734b	52b	5734	52
+6	ddd	ZZZ	65b	602b	65	602
+7	ßßß	SSS	7b	771b	 7	771
+8	vv	v	85b	832b	85	832
+9	v	vv	97	91	97	91
+10	GGG	nnn	101	102	101	102
+11	v12	PPP	1123b	1167b	1123	1167
+12	àbc	P	1209b	1234b	1209	1234
+13	ÀSSC		1367b	1331b	1367	1331
+14	-1	1	1489b	1421b	1489	1421
+15		B	1522b	1567b	1522	1567
+16			1634b	1602b	1634	1602
+17	0	X	1721b	1703	1721	1703
+18	a g  ß	Y	1845b	1801b	1845	1801
+19	%tg-0	Z	1931b	1956b	1931	1956
+20	bbb	ZZZ	21	28	21	28
+21	bbb	ZZZ	21	28	21	28
+22	ddd	ZZZ	65b	602b	65	602
+23	v12	PPP	1123b	1167b	1123	1167
+24	ÀSSC		1367b	1331b	1367	1331
+25	0	X	1721b	1703	1721	1703
+26	bbb	ZZZ	21	28	21	28
+31	 	 	sp-sp	2020b	sp-sp	2020
+
+====[tsv-join --header -f input1.tsv -k 2-3 -a 4-5 input2.tsv]====
 f1	f2	f3	f4	f5	f4	f5
 1	ggg	UUU	101b	15b	101	15
 2	bbb	ZZZ	21	28	21	28

--- a/tsv-join/tests/gold/error_tests_1.txt
+++ b/tsv-join/tests/gold/error_tests_1.txt
@@ -78,3 +78,20 @@ Error processing command line arguments: Cannot use '--a|append-fields 0' (whole
 
 ====[tsv-join --header --write-all MISSING -a 1 --exclude  -f input1.tsv -k 2,3 input2.tsv]====
 Error processing command line arguments: --e|exclude cannot be used with --a|append-fields.
+
+===Invalid field ranges===
+
+====[tsv-join --header -f input1.tsv -k 2,x input2.tsv]====
+Error processing command line arguments: [--k|key-fields] Unexpected 'x' when converting from type string to type ulong
+
+====[tsv-join --header -f input1.tsv -k 2,3 -d 2,1.5 input2.tsv]====
+Error processing command line arguments: [--d|data-fields] Unexpected '.' when converting from type string to type ulong
+
+====[tsv-join --header -f input1.tsv -k 2 -a 1- input2.tsv]====
+Error processing command line arguments: [--a|append-fields] Incomplete ranges are not supported: '1-'
+
+====[tsv-join --header -f input1.tsv -k 2,,4 input2.tsv]====
+Error processing command line arguments: [--k|key-fields] Empty field number.
+
+====[tsv-join --header -f input1.tsv -k input2.tsv]====
+Error processing command line arguments: [--k|key-fields] Unexpected 'i' when converting from type string to type ulong

--- a/tsv-join/tests/tests.sh
+++ b/tsv-join/tests/tests.sh
@@ -68,8 +68,11 @@ runtest ${prog} "--header -f input1.tsv -k 2 -d 3 -a 4 --allow-duplicate-keys -p
 runtest ${prog} "--header -f input1.tsv -k 2 -a 2,3 --allow-duplicate-keys -p i1_ input2.tsv" ${basic_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 2 -a 3,2 --allow-duplicate-keys -p i1_ input2.tsv" ${basic_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 2 -a 3,2,4 --allow-duplicate-keys -p i1_ input2.tsv" ${basic_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 2 -a 3-2,4 --allow-duplicate-keys -p i1_ input2.tsv" ${basic_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 2 -a 1,2,3,4,5 --allow-duplicate-keys -p i1_ input2.tsv" ${basic_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 2 -a 1-5 --allow-duplicate-keys -p i1_ input2.tsv" ${basic_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 2 -a 5,4,3,2,1 --allow-duplicate-keys -p i1_ input2.tsv" ${basic_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 2 -a 5-1 --allow-duplicate-keys -p i1_ input2.tsv" ${basic_tests_1}
 
 # Whole line appends
 echo "" >> ${basic_tests_1}; echo "====Whole line appends===" >> ${basic_tests_1}
@@ -82,15 +85,19 @@ echo "" >> ${basic_tests_1}; echo "====Multi-field keys===" >> ${basic_tests_1}
 
 runtest ${prog} "--header -f input1.tsv -k 2,3 input2.tsv" ${basic_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 3,2 -d 3,2 input2.tsv" ${basic_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 3-2 -d 3-2 input2.tsv" ${basic_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 3,2 input2.tsv" ${basic_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 2,3 -d 3,2 input2.tsv" ${basic_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 2,3,4 input2.tsv" ${basic_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 5,2,3 input2.tsv" ${basic_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 5,2-3 input2.tsv" ${basic_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 2,3 -e input2.tsv" ${basic_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 3,2 -e input2.tsv" ${basic_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 3,2 -d 3,2 -e input2.tsv" ${basic_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 3-2 -d 3-2 -e input2.tsv" ${basic_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 2,3 -a 4 input2.tsv" ${basic_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 2,3 -a 4,5 input2.tsv" ${basic_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 2-3 -a 4-5 input2.tsv" ${basic_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 2,3 -a 4 -p i1_ input2.tsv" ${basic_tests_1}
 runtest ${prog} "--header -f input1.tsv -k 2,3 -a 4,5 -p i1_ input2.tsv" ${basic_tests_1}
 
@@ -168,38 +175,45 @@ echo "Error test set 1" > ${error_tests_1}
 echo "----------------" >> ${error_tests_1}
 
 echo "" >> ${error_tests_1}; echo "===Duplicate keys===" >> ${error_tests_1}
-runtest ${prog} "--header -f input1.tsv -k 2 -a 0 input2.tsv" ${error_tests_1} 
-runtest ${prog} "--header -f input1.tsv -k 2 -a 4 input2.tsv" ${error_tests_1} 
+runtest ${prog} "--header -f input1.tsv -k 2 -a 0 input2.tsv" ${error_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 2 -a 4 input2.tsv" ${error_tests_1}
 
 echo "" >> ${error_tests_1}; echo "===Invalid field indicies===" >> ${error_tests_1}
-runtest ${prog} "--header -f input1.tsv -k 6 input2.tsv" ${error_tests_1} 
-runtest ${prog} "--header -f input1.tsv -k 4 -a 6 input2.tsv" ${error_tests_1} 
-runtest ${prog} "--header -f input1.tsv -k 4 -d 6 input2.tsv" ${error_tests_1} 
+runtest ${prog} "--header -f input1.tsv -k 6 input2.tsv" ${error_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 4 -a 6 input2.tsv" ${error_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 4 -d 6 input2.tsv" ${error_tests_1}
 
 echo "" >> ${error_tests_1}; echo "===Missing filter file===" >> ${error_tests_1}
-runtest ${prog} "--header -k 2 input2.tsv" ${error_tests_1} 
+runtest ${prog} "--header -k 2 input2.tsv" ${error_tests_1}
 
 echo "" >> ${error_tests_1}; echo "===Invalid Whole line and individual field combos===" >> ${error_tests_1}
-runtest ${prog} "--header -f input1.tsv -k 2,0 input2.tsv" ${error_tests_1} 
-runtest ${prog} "--header -f input1.tsv -k 0,2 input2.tsv" ${error_tests_1} 
-runtest ${prog} "--header -f input1.tsv -k 2,3 -d 0,2 input2.tsv" ${error_tests_1} 
-runtest ${prog} "--header -f input1.tsv -k 2,3 -d 2,0 input2.tsv" ${error_tests_1} 
-runtest ${prog} "--header -f input1.tsv -k 2 -d 0 input2.tsv" ${error_tests_1} 
-runtest ${prog} "--header -f input1.tsv -k 0 -d 2 input2.tsv" ${error_tests_1} 
+runtest ${prog} "--header -f input1.tsv -k 2,0 input2.tsv" ${error_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 0,2 input2.tsv" ${error_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 2,3 -d 0,2 input2.tsv" ${error_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 2,3 -d 2,0 input2.tsv" ${error_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 2 -d 0 input2.tsv" ${error_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 0 -d 2 input2.tsv" ${error_tests_1}
 
 echo "" >> ${error_tests_1}; echo "===Different number of filter and data keys===" >> ${error_tests_1}
-runtest ${prog} "--header -f input1.tsv -k 2 -d 2,3 input2.tsv" ${error_tests_1} 
-runtest ${prog} "--header -f input1.tsv -k 2,3 -d 2 input2.tsv" ${error_tests_1} 
+runtest ${prog} "--header -f input1.tsv -k 2 -d 2,3 input2.tsv" ${error_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 2,3 -d 2 input2.tsv" ${error_tests_1}
 
 echo "" >> ${error_tests_1}; echo "===Header prefix without header===" >> ${error_tests_1}
-runtest ${prog} "--prefix -f input1.tsv -k 2 input1_ input2.tsv" ${error_tests_1} 
+runtest ${prog} "--prefix -f input1.tsv -k 2 input1_ input2.tsv" ${error_tests_1}
 
 echo "" >> ${error_tests_1}; echo "===Exclude with an append field===" >> ${error_tests_1}
-runtest ${prog} "--header --exclude -a 3 -f input1.tsv -k 6 input2.tsv" ${error_tests_1} 
+runtest ${prog} "--header --exclude -a 3 -f input1.tsv -k 6 input2.tsv" ${error_tests_1}
 
 echo "" >> ${error_tests_1}; echo "===Invalid write-all combinations===" >> ${error_tests_1}
-runtest ${prog} "--header --write-all MISSING -f input1.tsv -k 2,3 input2.tsv" ${error_tests_1} 
-runtest ${prog} "--header --write-all MISSING -a 0 -f input1.tsv -k 2,3 input2.tsv" ${error_tests_1} 
+runtest ${prog} "--header --write-all MISSING -f input1.tsv -k 2,3 input2.tsv" ${error_tests_1}
+runtest ${prog} "--header --write-all MISSING -a 0 -f input1.tsv -k 2,3 input2.tsv" ${error_tests_1}
 runtest ${prog} "--header --write-all MISSING -a 1 --exclude  -f input1.tsv -k 2,3 input2.tsv" ${error_tests_1}
+
+echo "" >> ${error_tests_1}; echo "===Invalid field ranges===" >> ${error_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 2,x input2.tsv" ${error_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 2,3 -d 2,1.5 input2.tsv" ${error_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 2 -a 1- input2.tsv" ${error_tests_1}
+runtest ${prog} "--header -f input1.tsv -k 2,,4 input2.tsv" ${error_tests_1}
+runtest ${prog} "--header -f input1.tsv -k input2.tsv" ${error_tests_1}
 
 exit $?

--- a/tsv-select/src/tsv-select.d
+++ b/tsv-select/src/tsv-select.d
@@ -77,7 +77,8 @@ struct TsvSelectOptions
     {
         import std.algorithm : any, each;
         import std.getopt;
-        import tsvutil : makeFieldListOptionHandler;
+        import std.typecons : Yes, No;
+        import tsvutil :  makeFieldListOptionHandler;
 
         try
         {
@@ -87,7 +88,10 @@ struct TsvSelectOptions
                 std.getopt.config.caseSensitive,
                 "H|header",    "                 Treat the first line of each file as a header.", &hasHeader,
                 std.getopt.config.caseInsensitive,
-                "f|fields",    "<field-list>     (Required) Fields to extract. Fields are output in the order listed.", fields.makeFieldListOptionHandler,
+
+                "f|fields",    "<field-list>     (Required) Fields to extract. Fields are output in the order listed.",
+                fields.makeFieldListOptionHandler!(size_t, Yes.convertToZeroBasedIndex),
+
                 "r|rest",      "none|first|last  Location for remaining fields. Default: none", &rest,
                 "d|delimiter", "CHR              Character to use as field delimiter. Default: TAB. (Single byte UTF-8 characters only.)", &delim,
                 std.getopt.config.caseSensitive,
@@ -112,16 +116,6 @@ struct TsvSelectOptions
             {
                 throw new Exception("Required option --f|fields was not supplied.");
             }
-
-            if (fields.length > 0 && fields.any!(x => x == 0))
-            {
-                throw new Exception("Zero is not a valid field number (--f|fields).");
-            }
-
-            /* Derivations */
-            fields.each!((ref x) => --x);  // Convert to 1-based indexing. Using 'ref' in the lambda allows the actual
-                                           // field value to be modified. Otherwise a copy would be passed.
-
         }
         catch (Exception exc)
         {

--- a/tsv-select/src/tsv-select.d
+++ b/tsv-select/src/tsv-select.d
@@ -27,10 +27,12 @@ import std.typecons : tuple, Tuple;
 
 // 'Heredoc' style help text. When printed it is followed by a getopt formatted option list.
 auto helpText = q"EOS
-Synopsis: tsv-select -f n[,n...] [options] [file...]
+Synopsis: tsv-select -f <field-list> [options] [file...]
 
 tsv-select reads files or standard input and writes specified fields to standard
 output in the order listed. Similar to 'cut' with the ability to reorder fields.
+
+Fields numbers start with one. They are comma separated, and ranges can be used.
 Fields can be listed more than once, and fields not listed can be output using
 the --rest option. Multiple files with header lines can be managed with the
 --header option, which retains the header of the first file and drops the rest.
@@ -38,14 +40,16 @@ the --rest option. Multiple files with header lines can be managed with the
 Examples:
 
    tsv-select -f 4,2,9 file1.tsv file2.tsv
+   tsv-select -f 1,4-7,11 file1.tsv
+   tsv-select -f 1,7-4,11 file1.tsv
    tsv-select --delimiter ' ' -f 2,4,6 --rest last file1.txt
    cat file*.tsv | tsv-select -f 3,2,1
 
 Options:
 EOS";
 
-/** 
-Container for command line options. 
+/**
+Container for command line options.
  */
 struct TsvSelectOptions
 {
@@ -59,7 +63,7 @@ struct TsvSelectOptions
     bool versionWanted = false; // --V|version
 
     /** Process command line arguments (getopt cover).
-     * 
+     *
      * processArgs calls getopt to process command line arguments. It does any additional
      * validation and parameter derivations needed. A tuple is returned. First value is
      * true if command line arguments were successfully processed and execution should
@@ -68,12 +72,13 @@ struct TsvSelectOptions
      *
      * Returning true (execution continues) means args have been validated and derived
      * values calculated. In addition, field indices have been converted to zero-based.
-     */ 
+     */
     auto processArgs (ref string[] cmdArgs)
     {
         import std.algorithm : any, each;
         import std.getopt;
-        
+        import tsvutil : makeFieldListOptionHandler;
+
         try
         {
             arraySep = ",";    // Use comma to separate values in command line options
@@ -82,14 +87,14 @@ struct TsvSelectOptions
                 std.getopt.config.caseSensitive,
                 "H|header",    "                 Treat the first line of each file as a header.", &hasHeader,
                 std.getopt.config.caseInsensitive,
-                "f|fields",    "n[,n...]         (Required) Fields to extract. Fields are output in the order listed.", &fields,
+                "f|fields",    "<field-list>     (Required) Fields to extract. Fields are output in the order listed.", fields.makeFieldListOptionHandler,
                 "r|rest",      "none|first|last  Location for remaining fields. Default: none", &rest,
                 "d|delimiter", "CHR              Character to use as field delimiter. Default: TAB. (Single byte UTF-8 characters only.)", &delim,
                 std.getopt.config.caseSensitive,
                 "V|version",   "                 Print version information and exit.", &versionWanted,
                 std.getopt.config.caseInsensitive,
                 );
-            
+
             if (r.helpWanted)
             {
                 defaultGetoptPrinter(helpText, r.options);
@@ -101,13 +106,13 @@ struct TsvSelectOptions
                 writeln(tsvutilsVersionNotice("tsv-select"));
                 return tuple(false, 0);
             }
-        
+
             /* Consistency checks */
             if (fields.length == 0)
             {
                 throw new Exception("Required option --f|fields was not supplied.");
             }
-        
+
             if (fields.length > 0 && fields.any!(x => x == 0))
             {
                 throw new Exception("Zero is not a valid field number (--f|fields).");
@@ -116,7 +121,7 @@ struct TsvSelectOptions
             /* Derivations */
             fields.each!((ref x) => --x);  // Convert to 1-based indexing. Using 'ref' in the lambda allows the actual
                                            // field value to be modified. Otherwise a copy would be passed.
-            
+
         }
         catch (Exception exc)
         {
@@ -138,7 +143,7 @@ int main(string[] cmdArgs)
         import core.runtime : dmd_coverSetMerge;
         dmd_coverSetMerge(true);
     }
-    
+
     TsvSelectOptions cmdopt;
     auto r = cmdopt.processArgs(cmdArgs);
     if (!r[0]) return r[1];
@@ -153,10 +158,10 @@ int main(string[] cmdArgs)
         case TsvSelectOptions.RestOptionVal.none:
             tsvSelect!(CTERestLocation.none)(cmdopt, cmdArgs[1..$]);
             break;
-        case TsvSelectOptions.RestOptionVal.first: 
+        case TsvSelectOptions.RestOptionVal.first:
             tsvSelect!(CTERestLocation.first)(cmdopt, cmdArgs[1..$]);
             break;
-        case TsvSelectOptions.RestOptionVal.last: 
+        case TsvSelectOptions.RestOptionVal.last:
             tsvSelect!(CTERestLocation.last)(cmdopt, cmdArgs[1..$]);
             break;
         default:
@@ -187,7 +192,7 @@ enum CTERestLocation { none, first, last };
 
 /**
 tsvSelect does the primary work of the tsv-select program.
- 
+
 Input is read line by line, extracting the listed fields and writing them out in the order
 specified. An exception is thrown on error.
 
@@ -204,7 +209,7 @@ void tsvSelect(CTERestLocation cteRest)(in TsvSelectOptions cmdopt, in string[] 
     import std.format: format;
     import std.range;
 
-    // Ensure the correct template instantiation was called. 
+    // Ensure the correct template instantiation was called.
     static if (cteRest == CTERestLocation.none)
         assert(cmdopt.rest == TsvSelectOptions.RestOptionVal.none);
     else static if (cteRest == CTERestLocation.first)

--- a/tsv-select/tests/gold/basic_tests_1.txt
+++ b/tsv-select/tests/gold/basic_tests_1.txt
@@ -122,6 +122,72 @@ f4-empty	sss
  	 
 Z	0.0
 
+====[tsv-select -f 2,2 -r none input1.tsv]====
+f2	f2
+ggg	ggg
+f1-empty	f1-empty
+ßßß	ßßß
+sss	sss
+ÀBC	ÀBC
+	
+ 	 
+0.0	0.0
+
+====[tsv-select -f 2-3 input1.tsv]====
+f2	f3
+ggg	UUU
+f1-empty	CCC
+ßßß	SSS
+sss	f4-empty
+ÀBC	
+	
+ 	 
+0.0	Z
+
+====[tsv-select -f 4-1 input1.tsv]====
+f4	f3	f2	f1
+101	UUU	ggg	1
+5734	CCC	f1-empty	
+ 7	SSS	ßßß	3
+	f4-empty	sss	4
+1367		ÀBC	5
+f23-empty			6
+f23-space	 	 	7
+1931	Z	0.0	8
+
+====[tsv-select -f 2-2 input1.tsv]====
+f2
+ggg
+f1-empty
+ßßß
+sss
+ÀBC
+
+ 
+0.0
+
+====[tsv-select -f 2-3,1 input1.tsv]====
+f2	f3	f1
+ggg	UUU	1
+f1-empty	CCC	
+ßßß	SSS	3
+sss	f4-empty	4
+ÀBC		5
+		6
+ 	 	7
+0.0	Z	8
+
+====[tsv-select -f 2-3,1,4-3 input1.tsv]====
+f2	f3	f1	f4	f3
+ggg	UUU	1	101	UUU
+f1-empty	CCC		5734	CCC
+ßßß	SSS	3	 7	SSS
+sss	f4-empty	4		f4-empty
+ÀBC		5	1367	
+		6	f23-empty	
+ 	 	7	f23-space	 
+0.0	Z	8	1931	Z
+
 ====[tsv-select --fields 1 --rest first input1.tsv]====
 f2	f3	f4	f1
 ggg	UUU	101	1
@@ -145,6 +211,17 @@ f1	f2	f4	f3
 8	0.0	1931	Z
 
 ====[tsv-select -f 2,3 --rest first input1.tsv]====
+f1	f4	f2	f3
+1	101	ggg	UUU
+	5734	f1-empty	CCC
+3	 7	ßßß	SSS
+4		sss	f4-empty
+5	1367	ÀBC	
+6	f23-empty		
+7	f23-space	 	 
+8	1931	0.0	Z
+
+====[tsv-select -f 2-3 --rest first input1.tsv]====
 f1	f4	f2	f3
 1	101	ggg	UUU
 	5734	f1-empty	CCC

--- a/tsv-select/tests/gold/error_tests_1.txt
+++ b/tsv-select/tests/gold/error_tests_1.txt
@@ -8,7 +8,7 @@ Error processing command line arguments: Required option --f|fields was not supp
 Error processing command line arguments: Required option --f|fields was not supplied.
 
 ====[tsv-select input1.tsv --fields last]====
-Error processing command line arguments: [--f|fields] Unexpected 'l' when converting from type string to type ulong
+Error processing command line arguments: [--f|fields] Unexpected 'l' when converting from type string to type long
 
 ====[tsv-select -f 0 input1.tsv]====
 Error processing command line arguments: [--f|fields] Field numbers must be greater than zero: '0'
@@ -40,10 +40,10 @@ Error processing command line arguments: [--f|fields] Incomplete ranges are not 
 Error processing command line arguments: [--f|fields] Incomplete ranges are not supported: '3-'
 
 ====[tsv-select -f input1.tsv]====
-Error processing command line arguments: [--f|fields] Unexpected 'i' when converting from type string to type ulong
+Error processing command line arguments: [--f|fields] Unexpected 'i' when converting from type string to type long
 
 ====[tsv-select -f 1, input1.tsv]====
 Error processing command line arguments: [--f|fields] Empty field number.
 
 ====[tsv-select -f 1.1 input1.tsv]====
-Error processing command line arguments: [--f|fields] Unexpected '.' when converting from type string to type ulong
+Error processing command line arguments: [--f|fields] Unexpected '.' when converting from type string to type long

--- a/tsv-select/tests/gold/error_tests_1.txt
+++ b/tsv-select/tests/gold/error_tests_1.txt
@@ -7,8 +7,11 @@ Error processing command line arguments: Required option --f|fields was not supp
 ====[tsv-select input1.tsv --rest last]====
 Error processing command line arguments: Required option --f|fields was not supplied.
 
+====[tsv-select input1.tsv --fields last]====
+Error processing command line arguments: [--f|fields] Unexpected 'l' when converting from type string to type ulong
+
 ====[tsv-select -f 0 input1.tsv]====
-Error processing command line arguments: Zero is not a valid field number (--f|fields).
+Error processing command line arguments: [--f|fields] Field numbers must be greater than zero: '0'
 
 ====[tsv-select input1.tsv -f 2 --rest elsewhere]====
 Error processing command line arguments: RestOptionVal does not have a member named 'elsewhere'
@@ -26,3 +29,21 @@ Error processing command line arguments: Invalid UTF-8 sequence (at index 1)
 
 ====[tsv-select -f 1 --nosuchparam input1.tsv]====
 Error processing command line arguments: Unrecognized option --nosuchparam
+
+====[tsv-select -f 0-1 input1.tsv]====
+Error processing command line arguments: [--f|fields] Field numbers must be greater than zero: '0'
+
+====[tsv-select -f 2- input1.tsv]====
+Error processing command line arguments: [--f|fields] Incomplete ranges are not supported: '2-'
+
+====[tsv-select -f 1,3- input1.tsv]====
+Error processing command line arguments: [--f|fields] Incomplete ranges are not supported: '3-'
+
+====[tsv-select -f input1.tsv]====
+Error processing command line arguments: [--f|fields] Unexpected 'i' when converting from type string to type ulong
+
+====[tsv-select -f 1, input1.tsv]====
+Error processing command line arguments: [--f|fields] Empty field number.
+
+====[tsv-select -f 1.1 input1.tsv]====
+Error processing command line arguments: [--f|fields] Unexpected '.' when converting from type string to type ulong

--- a/tsv-select/tests/tests.sh
+++ b/tsv-select/tests/tests.sh
@@ -39,11 +39,20 @@ runtest ${prog} "-f 3,1,4 input1.tsv" ${basic_tests_1}
 runtest ${prog} "-f 4,3,2,1 input1.tsv" ${basic_tests_1}
 runtest ${prog} "-f 4,1 --rest none input1.tsv" ${basic_tests_1}
 runtest ${prog} "-f 3,2 -r none input1.tsv" ${basic_tests_1}
+runtest ${prog} "-f 2,2 -r none input1.tsv" ${basic_tests_1}
+
+# Field ranges
+runtest ${prog} "-f 2-3 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-f 4-1 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-f 2-2 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-f 2-3,1 input1.tsv" ${basic_tests_1}
+runtest ${prog} "-f 2-3,1,4-3 input1.tsv" ${basic_tests_1}
 
 # --rest first
 runtest ${prog} "--fields 1 --rest first input1.tsv" ${basic_tests_1}
 runtest ${prog} "-f 3 --rest first input1.tsv" ${basic_tests_1}
 runtest ${prog} "-f 2,3 --rest first input1.tsv" ${basic_tests_1}
+runtest ${prog} "-f 2-3 --rest first input1.tsv" ${basic_tests_1}
 runtest ${prog} "-f 4,3 -r first input1.tsv" ${basic_tests_1}
 runtest ${prog} "-f 3,1,4 -r first input1.tsv" ${basic_tests_1}
 runtest ${prog} "-f 4,3,2,1 -r first input1.tsv" ${basic_tests_1}
@@ -143,7 +152,7 @@ runtest ${prog} "input1.tsv --rest last" ${error_tests_1}
 
 # Disable this test until Phobos 2.071 is available on all compilers
 # 2.071 changed the error message in a minor way.
-#runtest ${prog} "input1.tsv --fields last" ${error_tests_1}
+runtest ${prog} "input1.tsv --fields last" ${error_tests_1}
 
 runtest ${prog} "-f 0 input1.tsv" ${error_tests_1}
 runtest ${prog} "input1.tsv -f 2 --rest elsewhere" ${error_tests_1}
@@ -151,5 +160,12 @@ runtest ${prog} "-f 1 nosuchfile.tsv" ${error_tests_1}
 runtest ${prog} "-f 1,4 input_3plus_fields.tsv" ${error_tests_1}
 runtest ${prog} "-d ß -f 1 input1.tsv" ${error_tests_1}
 runtest ${prog} "-f 1 --nosuchparam input1.tsv" ${error_tests_1}
+
+runtest ${prog} "-f 0-1 input1.tsv" ${error_tests_1}
+runtest ${prog} "-f 2- input1.tsv" ${error_tests_1}
+runtest ${prog} "-f 1,3- input1.tsv" ${error_tests_1}
+runtest ${prog} "-f input1.tsv" ${error_tests_1}
+runtest ${prog} "-f 1, input1.tsv" ${error_tests_1}
+runtest ${prog} "-f 1.1 input1.tsv" ${error_tests_1}
 
 exit $?

--- a/tsv-summarize/src/tsv-summarize.d
+++ b/tsv-summarize/src/tsv-summarize.d
@@ -85,14 +85,15 @@ Most operators take custom headers in a similarly way, generally following:
   --<operator-name> FIELD[:header]
 
 Operators can be specified multiple times. They can also take multiple
-fields (though not when a custom header is specified). Example:
+fields (though not when a custom header is specified). Examples:
 
   --median 2,3,4
+  --median 2-5,7-11
 
 The quantile operator requires one or more probabilities after the fields:
 
   --quantile 2:0.25                // Quantile 1 of field 2
-  --quantile 2,3,4:0.25,0.5,0.75   // Q1, Median, Q3 of fields 2, 3, 4
+  --quantile 2-4:0.25,0.5,0.75     // Q1, Median, Q3 of fields 2, 3, 4
 
 Summarization operators available are:
   count       range        mad            values
@@ -193,25 +194,25 @@ struct TsvSummarizeOptions {
                 "count",              "              Count occurrences of each unique key.", &countOptionHandler,
                 "count-header",       "STR           Count occurrences of each unique key, use header STR.", &countHeaderOptionHandler,
                 "retain",             "<field-list>  Retain one copy of the field.", &operatorOptionHandler!RetainOperator,
-                "first",              "<field-list>|NUM:STR  First value seen.", &operatorOptionHandler!FirstOperator,
-                "last",               "<field-list>|NUM:STR  Last value seen.", &operatorOptionHandler!LastOperator,
-                "min",                "<field-list>|NUM:STR  Min value. (Numeric fields only.)", &operatorOptionHandler!MinOperator,
-                "max",                "<field-list>|NUM:STR  Max value. (Numeric fields only.)", &operatorOptionHandler!MaxOperator,
-                "range",              "<field-list>|NUM:STR  Difference between min and max values. (Numeric fields only.)", &operatorOptionHandler!RangeOperator,
-                "sum",                "<field-list>|NUM:STR  Sum of the values. (Numeric fields only.)", &operatorOptionHandler!SumOperator,
-                "mean",               "<field-list>|NUM:STR  Mean (average). (Numeric fields only.)", &operatorOptionHandler!MeanOperator,
-                "median",             "<field-list>|NUM:STR  Median value. (Numeric fields only. Reads all values into memory.)", &operatorOptionHandler!MedianOperator,
-                "quantile",           "n[,n...]:p[,p...][:STR]  Quantiles. One or more fields, then one or more 0.0-1.0 probabilities. (Numeric fields only. Reads all values into memory.)", &quantileOperatorOptionHandler,
-                "mad",                "<field-list>|NUM:STR  Median absolute deviation from the median. Raw value, not scaled. (Numeric fields only. Reads all values into memory.)", &operatorOptionHandler!MadOperator,
-                "var",                "<field-list>|NUM:STR  Variance. (Sample variance, numeric fields only).", &operatorOptionHandler!VarianceOperator,
-                "stdev",              "<field-list>|NUM:STR  Standard deviation. (Sample st.dev, numeric fields only).", &operatorOptionHandler!StDevOperator,
-                "mode",               "<field-list>|NUM:STR  Mode. The most frequent value. (Reads all unique values into memory.)", &operatorOptionHandler!ModeOperator,
-                "mode-count",         "<field-list>|NUM:STR  Count of the most frequent value. (Reads all unique values into memory.)", &operatorOptionHandler!ModeCountOperator,
-                "unique-count",       "<field-list>|NUM:STR  Number of unique values. (Reads all unique values into memory.)", &operatorOptionHandler!UniqueCountOperator,
-                "missing-count",      "<field-list>|NUM:STR  Number of missing (empty) fields. Not affected by '--x|exclude-missing' or '--r|replace-missing'.", &operatorOptionHandler!MissingCountOperator,
-                "not-missing-count",  "<field-list>|NUM:STR  Number of filled (non-empty) fields. Not affected by '--r|replace-missing'.", &operatorOptionHandler!NotMissingCountOperator,
-                "values",             "<field-list>|NUM:STR  All the values, separated by --v|values-delimiter. (Reads all values into memory.)", &operatorOptionHandler!ValuesOperator,
-                "unique-values",      "<field-list>|NUM:STR  All the unique values, separated by --v|values-delimiter. (Reads all unique values into memory.)", &operatorOptionHandler!UniqueValuesOperator,
+                "first",              "<field-list>[:STR]  First value seen.", &operatorOptionHandler!FirstOperator,
+                "last",               "<field-list>[:STR]  Last value seen.", &operatorOptionHandler!LastOperator,
+                "min",                "<field-list>[:STR]  Min value. (Numeric fields only.)", &operatorOptionHandler!MinOperator,
+                "max",                "<field-list>[:STR]  Max value. (Numeric fields only.)", &operatorOptionHandler!MaxOperator,
+                "range",              "<field-list>[:STR]  Difference between min and max values. (Numeric fields only.)", &operatorOptionHandler!RangeOperator,
+                "sum",                "<field-list>[:STR]  Sum of the values. (Numeric fields only.)", &operatorOptionHandler!SumOperator,
+                "mean",               "<field-list>[:STR]  Mean (average). (Numeric fields only.)", &operatorOptionHandler!MeanOperator,
+                "median",             "<field-list>[:STR]  Median value. (Numeric fields only. Reads all values into memory.)", &operatorOptionHandler!MedianOperator,
+                "quantile",           "<field-list>:p[,p...][:STR]  Quantiles. One or more fields, then one or more 0.0-1.0 probabilities. (Numeric fields only. Reads all values into memory.)", &quantileOperatorOptionHandler,
+                "mad",                "<field-list>[:STR]  Median absolute deviation from the median. Raw value, not scaled. (Numeric fields only. Reads all values into memory.)", &operatorOptionHandler!MadOperator,
+                "var",                "<field-list>[:STR]  Variance. (Sample variance, numeric fields only).", &operatorOptionHandler!VarianceOperator,
+                "stdev",              "<field-list>[:STR]  Standard deviation. (Sample st.dev, numeric fields only).", &operatorOptionHandler!StDevOperator,
+                "mode",               "<field-list>[:STR]  Mode. The most frequent value. (Reads all unique values into memory.)", &operatorOptionHandler!ModeOperator,
+                "mode-count",         "<field-list>[:STR]  Count of the most frequent value. (Reads all unique values into memory.)", &operatorOptionHandler!ModeCountOperator,
+                "unique-count",       "<field-list>[:STR]  Number of unique values. (Reads all unique values into memory.)", &operatorOptionHandler!UniqueCountOperator,
+                "missing-count",      "<field-list>[:STR]  Number of missing (empty) fields. Not affected by '--x|exclude-missing' or '--r|replace-missing'.", &operatorOptionHandler!MissingCountOperator,
+                "not-missing-count",  "<field-list>[:STR]  Number of filled (non-empty) fields. Not affected by '--r|replace-missing'.", &operatorOptionHandler!NotMissingCountOperator,
+                "values",             "<field-list>[:STR]  All the values, separated by --v|values-delimiter. (Reads all values into memory.)", &operatorOptionHandler!ValuesOperator,
+                "unique-values",      "<field-list>[:STR]  All the unique values, separated by --v|values-delimiter. (Reads all unique values into memory.)", &operatorOptionHandler!UniqueValuesOperator,
                 );
 
             if (r.helpWanted)
@@ -306,7 +307,7 @@ struct TsvSummarizeOptions {
         auto formatErrorMsg(string option, string optionVal)
         {
             return format(
-                "Invalid option value: '--%s %s'. Expected: '--%s <field>[,<field>]:<prob>[,<prob>]' or '--%s <field>:<prob>:<header>' where <field> is a field number, <prob> is a number between 0.0 and 1.0, and <header> a string.",
+                "Invalid option value: '--%s %s'. Expected: '--%s <field-list>:<prob>[,<prob>]' or '--%s <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.",
                 option, optionVal, option, option);
         }
 
@@ -1019,63 +1020,77 @@ unittest
                     ["c", "c|c|c", "a|bc|bc", "2b||3"],
                     ["",  "",      "bc",      ""]]
         );
-    testSummarizer(["unittest-sk-5", "-H", "--group-by", "1", "--values", "3,2,1"],
+    testSummarizer(["unittest-sk-5", "-H", "--group-by", "1", "--values", "1-3"],
+                   file1,
+                   [["fld1", "fld1_values", "fld2_values", "fld3_values"],
+                    ["a", "a|a",   "a|c",     "3|2b"],
+                    ["c", "c|c|c", "a|bc|bc", "2b||3"],
+                    ["",  "",      "bc",      ""]]
+        );
+    testSummarizer(["unittest-sk-6", "-H", "--group-by", "1", "--values", "3,2,1"],
                    file1,
                    [["fld1", "fld3_values", "fld2_values", "fld1_values"],
                     ["a", "3|2b",  "a|c",     "a|a"],
                     ["c", "2b||3", "a|bc|bc", "c|c|c"],
                     ["",  "",      "bc",      ""]]
         );
-    testSummarizer(["unittest-sk-6", "-H", "--group-by", "2", "--values", "1"],
+    testSummarizer(["unittest-sk-7", "-H", "--group-by", "1", "--values", "3-1"],
+                   file1,
+                   [["fld1", "fld3_values", "fld2_values", "fld1_values"],
+                    ["a", "3|2b",  "a|c",     "a|a"],
+                    ["c", "2b||3", "a|bc|bc", "c|c|c"],
+                    ["",  "",      "bc",      ""]]
+        );
+    testSummarizer(["unittest-sk-8", "-H", "--group-by", "2", "--values", "1"],
                    file1,
                    [["fld2", "fld1_values"],
                     ["a",  "a|c"],
                     ["bc", "c||c"],
                     ["c",  "a"]]
         );
-    testSummarizer(["unittest-sk-7", "-H", "--group-by", "2", "--values", "2"],
+    testSummarizer(["unittest-sk-9", "-H", "--group-by", "2", "--values", "2"],
                    file1,
                    [["fld2", "fld2_values"],
                     ["a",  "a|a"],
                     ["bc", "bc|bc|bc"],
                     ["c",  "c"]]
         );
-    testSummarizer(["unittest-sk-8", "-H", "--group-by", "2", "--values", "3"],
+    testSummarizer(["unittest-sk-10", "-H", "--group-by", "2", "--values", "3"],
                    file1,
                    [["fld2", "fld3_values"],
                     ["a",  "3|2b"],
                     ["bc", "||3"],
                     ["c",  "2b"]]
         );
-    testSummarizer(["unittest-sk-9", "-H", "--group-by", "2", "--values", "1,3"],
+    testSummarizer(["unittest-sk-11", "-H", "--group-by", "2", "--values", "1,3"],
                    file1,
                    [["fld2", "fld1_values", "fld3_values"],
                     ["a",  "a|c",  "3|2b"],
                     ["bc", "c||c", "||3"],
                     ["c",  "a",    "2b"]]
         );
-    testSummarizer(["unittest-sk-10", "-H", "--group-by", "2", "--values", "3,1"],
+    testSummarizer(["unittest-sk-12", "-H", "--group-by", "2", "--values", "3,1"],
                    file1,
                    [["fld2", "fld3_values", "fld1_values"],
                     ["a",  "3|2b", "a|c"],
                     ["bc", "||3",  "c||c"],
                     ["c",  "2b",   "a"]]
         );
-    testSummarizer(["unittest-sk-11", "-H", "--group-by", "3", "--values", "1"],
+    testSummarizer(["unittest-sk-13", "-H", "--group-by", "3", "--values", "1"],
                    file1,
                    [["fld3", "fld1_values"],
                     ["3",  "a|c"],
                     ["2b", "c|a"],
                     ["",   "c|"]]
         );
-    testSummarizer(["unittest-sk-12", "-H", "--group-by", "3", "--values", "2"],
+    testSummarizer(["unittest-sk-14", "-H", "--group-by", "3", "--values", "2"],
                    file1,
                    [["fld3", "fld2_values"],
                     ["3",  "a|bc"],
                     ["2b", "a|c"],
                     ["",   "bc|bc"]]
         );
-    testSummarizer(["unittest-sk-13", "-H", "--group-by", "3", "--values", "1,2"],
+    testSummarizer(["unittest-sk-15", "-H", "--group-by", "3", "--values", "1,2"],
                    file1,
                    [["fld3", "fld1_values", "fld2_values"],
                     ["3",  "a|c", "a|bc"],
@@ -1130,7 +1145,16 @@ unittest
                     ["2b", "c",  "a"],
                     ["3",  "bc", "c"]]
         );
-    testSummarizer(["unittest-mk-6", "-H", "--group-by", "2,1,3", "--values", "2"],
+    testSummarizer(["unittest-mk-6", "-H", "--group-by", "3-2", "--values", "1"],
+                   file1,
+                   [["fld3", "fld2", "fld1_values"],
+                    ["3",  "a",  "a"],
+                    ["2b", "a",  "c"],
+                    ["",   "bc", "c|"],
+                    ["2b", "c",  "a"],
+                    ["3",  "bc", "c"]]
+        );
+    testSummarizer(["unittest-mk-7", "-H", "--group-by", "2,1,3", "--values", "2"],
                    file1,
                    [["fld2", "fld1", "fld3", "fld2_values"],
                     ["a",  "a", "3",  "a"],
@@ -1328,6 +1352,16 @@ unittest
                     ["",  "",   "bc", "",   "",  "bc"],
                     ["c", "3",  "bc", "3",  "c", "bc"]]
         );
+    testSummarizer(["unittest-hdr-9", "--write-header", "--group-by", "1,3-2", "--values", "3", "--values", "1:ValsField1", "--values", "2:ValsField2"],
+                   file1[1..$],
+                   [["field1", "field3", "field2", "field3_values", "ValsField1", "ValsField2"],
+                    ["a", "3",  "a",  "3",  "a", "a"],
+                    ["c", "2b", "a",  "2b", "c", "a"],
+                    ["c", "",   "bc", "",   "c", "bc"],
+                    ["a", "2b", "c",  "2b", "a", "c"],
+                    ["",  "",   "bc", "",   "",  "bc"],
+                    ["c", "3",  "bc", "3",  "c", "bc"]]
+        );
 
     /* Alternate file widths and lengths.
      */
@@ -1505,7 +1539,7 @@ unittest
                    [["fld1_values", "fld2_values"],
                     ["a|c|c|a||c", "a|a|bc|c|bc|bc"]]
         );
-    testSummarizer(["unittest-delim-2", "-H", "--values", "1,2", "--values-delimiter", "$"],
+    testSummarizer(["unittest-delim-2", "-H", "--values", "1-2", "--values-delimiter", "$"],
                    file1,
                    [["fld1_values", "fld2_values"],
                     ["a$c$c$a$$c", "a$a$bc$c$bc$bc"]]

--- a/tsv-summarize/tests/gold/basic_tests_1.txt
+++ b/tsv-summarize/tests/gold/basic_tests_1.txt
@@ -27,6 +27,14 @@ blue	solid	2	14	2	3	16	4	4
 green	solid	2	7.4	5.5	3.2	11	6	5.4
 blue	striped	1	12	1	2	12	1	2
 
+====[tsv-summarize --header --group-by 1-2 --count --min 3-5 --max 5-3 input_5field_a.tsv]====
+color	pattern	count	length_min	width_min	height_min	height_max	width_max	length_max
+red	solid	1	10	4	7	7	4	10
+red	striped	1	8	6	6	6	6	8
+blue	solid	2	14	2	3	4	4	16
+green	solid	2	7.4	5.5	3.2	5.4	6	11
+blue	striped	1	12	1	2	2	1	12
+
 ====[tsv-summarize --header --count --min 3,4,5 --max 3,4,5 input_5field_a.tsv input_5field_b.tsv input_5field_c.tsv empty_file.tsv input_5field_header_only.tsv]====
 count	length_min	width_min	height_min	length_max	width_max	height_max
 12	6	1	2	16	7	8
@@ -59,6 +67,9 @@ green	2	3.6	0.5	2.2
 青	1	0	0	0
 
 ====[tsv-summarize --count --unique-count 1,2,3,4,5 input_5field_a.tsv empty_file.tsv input_5field_b.tsv input_5field_header_only.tsv input_5field_c.tsv]====
+16	6	6	10	8	11
+
+====[tsv-summarize --count --unique-count 1-5 input_5field_a.tsv empty_file.tsv input_5field_b.tsv input_5field_header_only.tsv input_5field_c.tsv]====
 16	6	6	10	8	11
 
 ====[tsv-summarize --count --group-by 1 --unique-count 2,3,4,5 input_5field_a.tsv empty_file.tsv input_5field_b.tsv input_5field_header_only.tsv input_5field_c.tsv]====

--- a/tsv-summarize/tests/gold/error_tests_1.txt
+++ b/tsv-summarize/tests/gold/error_tests_1.txt
@@ -5,31 +5,46 @@ Error test set 1
 Error: Cannot open file `no_such_file.tsv' in mode `rb' (No such file or directory)
 
 ====[tsv-summarize --unique-count 0 input_5field_a.tsv]====
-Error processing command line arguments: Invalid option: '--unique-count 0'. Zero is not a valid field index.
+Error processing command line arguments: [--unique-count] Field numbers must be greater than zero: '0'
 
 ====[tsv-summarize --unique-count 2, input_5field_a.tsv]====
-Error processing command line arguments: Invalid option value: '--unique-count 2,'. Expected: '--unique-count <field>[,<field>]' or '--unique-count <field>:<header>' where <field> is a number and <header> a string.
+Error processing command line arguments: [--unique-count] Empty field number.
 
 ====[tsv-summarize --unique-count 2: input_5field_a.tsv]====
-Error processing command line arguments: Invalid option value: '--unique-count 2:'. Expected: '--unique-count <field>[,<field>]' or '--unique-count <field>:<header>' where <field> is a number and <header> a string.
+Error processing command line arguments: Invalid option value: '--unique-count 2:'. Expected: '--unique-count <field-list>' or '--unique-count <field>:<header>'.
+
+====[tsv-summarize --unique-count 2,3:my_header input_5field_a.tsv]====
+Error processing command line arguments: [--unique-count] Invalid option: '--unique-count 2,3:my_header'. Cannot specify a custom header when using multiple fields.
+
+====[tsv-summarize --unique-count 2-5:my_header input_5field_a.tsv]====
+Error processing command line arguments: [--unique-count] Invalid option: '--unique-count 2-5:my_header'. Cannot specify a custom header when using multiple fields.
+
+====[tsv-summarize --retain 2:my_header input_5field_a.tsv]====
+Error processing command line arguments: [--retain] Invalid option: '--retain 2:my_header'. Operator does not support custom headers.
 
 ====[tsv-summarize --unique-count x input_5field_a.tsv]====
-Error processing command line arguments: Invalid option value: '--unique-count x'. Expected: '--unique-count <field>[,<field>]' or '--unique-count <field>:<header>' where <field> is a number and <header> a string.
+Error processing command line arguments: [--unique-count] Unexpected 'x' when converting from type string to type long
 
 ====[tsv-summarize --unique-count 2 input_5field_a.tsv input_1field_a.tsv]====
 Error: Not enough fields in line. File: input_1field_a.tsv, Line: 1
 
-====[tsv-summarize --group-by 0 input_5field_a.tsv]====
+====[tsv-summarize --group-by 1 input_5field_a.tsv]====
 Error processing command line arguments: At least one summary operator is required.
 
+====[tsv-summarize --group-by 0 --count input_5field_a.tsv]====
+Error processing command line arguments: [--g|group-by] Field numbers must be greater than zero: '0'
+
+====[tsv-summarize --group-by 0 input_5field_a.tsv]====
+Error processing command line arguments: [--g|group-by] Field numbers must be greater than zero: '0'
+
 ====[tsv-summarize --group-by 2, input_5field_a.tsv]====
-Error processing command line arguments: Unexpected end of input when converting from type string to type ulong
+Error processing command line arguments: [--g|group-by] Empty field number.
 
 ====[tsv-summarize --group-by 2: input_5field_a.tsv]====
-Error processing command line arguments: Unexpected ':' when converting from type string to type ulong
+Error processing command line arguments: [--g|group-by] Unexpected ':' when converting from type string to type long
 
 ====[tsv-summarize --group-by x input_5field_a.tsv]====
-Error processing command line arguments: Unexpected 'x' when converting from type string to type ulong
+Error processing command line arguments: [--g|group-by] Unexpected 'x' when converting from type string to type long
 
 ====[tsv-summarize --group-by 2 --unique-count 1 input_5field_a.tsv input_1field_a.tsv]====
 Error: Not enough fields in line. File: input_1field_a.tsv, Line: 1
@@ -63,7 +78,7 @@ Error processing command line arguments: Invalid option: '--quantile 3:2'. Proba
 Error processing command line arguments: Invalid option: '--quantile 3:0.5,2'. Probability '2' is not in the interval [0.0,1.0].
 
 ====[tsv-summarize --quantile 0:0.5 input_5field_a.tsv]====
-Error processing command line arguments: Invalid option: '--quantile 0:0.5'. Zero is not a valid field index.
+Error processing command line arguments: [--quantile] Field numbers must be greater than zero: '0'
 
 ====[tsv-summarize --quantile 3,4:0.75:q3 input_5field_a.tsv]====
 Error processing command line arguments: Invalid option: '--quantile 3,4:0.75:q3'. Cannot specify a custom header when using multiple fields or multiple probabilities.

--- a/tsv-summarize/tests/gold/error_tests_1.txt
+++ b/tsv-summarize/tests/gold/error_tests_1.txt
@@ -49,6 +49,12 @@ Error processing command line arguments: [--g|group-by] Unexpected 'x' when conv
 ====[tsv-summarize --group-by 2 --unique-count 1 input_5field_a.tsv input_1field_a.tsv]====
 Error: Not enough fields in line. File: input_1field_a.tsv, Line: 1
 
+====[tsv-summarize --group-by 1- input_5field_a.tsv]====
+Error processing command line arguments: [--g|group-by] Incomplete ranges are not supported: '1-'
+
+====[tsv-summarize --group-by 3-0 input_5field_a.tsv]====
+Error processing command line arguments: [--g|group-by] Field numbers must be greater than zero: '0'
+
 ====[tsv-summarize --header --max 1 input_1field_a.tsv]====
 Error: Could not process line or field: no digits seen
   File: input_1field_a.tsv Line: 3
@@ -69,7 +75,7 @@ Error processing command line arguments: Invalid UTF-8 sequence (at index 1)
 Error processing command line arguments: Cannot use both '--x|exclude-missing' and '--r|replace-missing'.
 
 ====[tsv-summarize --quantile 3 input_5field_a.tsv]====
-Error processing command line arguments: Invalid option value: '--quantile 3'. Expected: '--quantile <field>[,<field>]:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <field> is a field number, <prob> is a number between 0.0 and 1.0, and <header> a string.
+Error processing command line arguments: Invalid option value: '--quantile 3'. Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
 
 ====[tsv-summarize --quantile 3:2 input_5field_a.tsv]====
 Error processing command line arguments: Invalid option: '--quantile 3:2'. Probability '2' is not in the interval [0.0,1.0].
@@ -85,3 +91,21 @@ Error processing command line arguments: Invalid option: '--quantile 3,4:0.75:q3
 
 ====[tsv-summarize --quantile 3:0.25,0.75:q1q3 input_5field_a.tsv]====
 Error processing command line arguments: Invalid option: '--quantile 3:0.25,0.75:q1q3'. Cannot specify a custom header when using multiple fields or multiple probabilities.
+
+====[tsv-summarize --quantile 3, input_5field_a.tsv]====
+Error processing command line arguments: Invalid option value: '--quantile 3,'. Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
+
+====[tsv-summarize --quantile 3- input_5field_a.tsv]====
+Error processing command line arguments: Invalid option value: '--quantile 3-'. Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
+
+====[tsv-summarize --quantile 0:0.25 input_5field_a.tsv]====
+Error processing command line arguments: [--quantile] Field numbers must be greater than zero: '0'
+
+====[tsv-summarize --quantile 1.5:0.25 input_5field_a.tsv]====
+Error processing command line arguments: [--quantile] Unexpected '.' when converting from type string to type long
+
+====[tsv-summarize --quantile 1-:0.25 input_5field_a.tsv]====
+Error processing command line arguments: [--quantile] Incomplete ranges are not supported: '1-'
+
+====[tsv-summarize --quantile -2:0.25 input_5field_a.tsv]====
+Error processing command line arguments: Missing value for argument --quantile.

--- a/tsv-summarize/tests/tests.sh
+++ b/tsv-summarize/tests/tests.sh
@@ -114,8 +114,13 @@ runtest ${prog} "--count no_such_file.tsv" ${error_tests_1}
 runtest ${prog} "--unique-count 0 input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "--unique-count 2, input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "--unique-count 2: input_5field_a.tsv" ${error_tests_1}
+runtest ${prog} "--unique-count 2,3:my_header input_5field_a.tsv" ${error_tests_1}
+runtest ${prog} "--unique-count 2-5:my_header input_5field_a.tsv" ${error_tests_1}
+runtest ${prog} "--retain 2:my_header input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "--unique-count x input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "--unique-count 2 input_5field_a.tsv input_1field_a.tsv" ${error_tests_1}
+runtest ${prog} "--group-by 1 input_5field_a.tsv" ${error_tests_1}
+runtest ${prog} "--group-by 0 --count input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "--group-by 0 input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "--group-by 2, input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "--group-by 2: input_5field_a.tsv" ${error_tests_1}

--- a/tsv-summarize/tests/tests.sh
+++ b/tsv-summarize/tests/tests.sh
@@ -39,6 +39,7 @@ runtest ${prog} "--header --missing-count 1 --not-missing-count 1 input_1field_a
 runtest ${prog} "--header --count --min 3,4,5 --max 3,4,5 input_5field_a.tsv" ${basic_tests_1}
 runtest ${prog} "--header --group-by 1 --count --min 3,4,5 --max 3,4,5 input_5field_a.tsv" ${basic_tests_1}
 runtest ${prog} "--header --group-by 1,2 --count --min 3,4,5 --max 3,4,5 input_5field_a.tsv" ${basic_tests_1}
+runtest ${prog} "--header --group-by 1-2 --count --min 3-5 --max 5-3 input_5field_a.tsv" ${basic_tests_1}
 
 runtest ${prog} "--header --count --min 3,4,5 --max 3,4,5 input_5field_a.tsv input_5field_b.tsv input_5field_c.tsv empty_file.tsv input_5field_header_only.tsv" ${basic_tests_1}
 runtest ${prog} "--header --group-by 1 --count --min 3,4,5 --max 3,4,5 input_5field_a.tsv input_5field_b.tsv input_5field_c.tsv empty_file.tsv input_5field_header_only.tsv" ${basic_tests_1}
@@ -49,6 +50,7 @@ runtest ${prog} "--header --group-by 1 --count --range 3,4,5 input_5field_a.tsv 
 
 ## No header tests.
 runtest ${prog} "--count --unique-count 1,2,3,4,5 input_5field_a.tsv empty_file.tsv input_5field_b.tsv input_5field_header_only.tsv input_5field_c.tsv" ${basic_tests_1}
+runtest ${prog} "--count --unique-count 1-5 input_5field_a.tsv empty_file.tsv input_5field_b.tsv input_5field_header_only.tsv input_5field_c.tsv" ${basic_tests_1}
 
 runtest ${prog} "--count --group-by 1 --unique-count 2,3,4,5 input_5field_a.tsv empty_file.tsv input_5field_b.tsv input_5field_header_only.tsv input_5field_c.tsv" ${basic_tests_1}
 
@@ -126,6 +128,8 @@ runtest ${prog} "--group-by 2, input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "--group-by 2: input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "--group-by x input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "--group-by 2 --unique-count 1 input_5field_a.tsv input_1field_a.tsv" ${error_tests_1}
+runtest ${prog} "--group-by 1- input_5field_a.tsv" ${error_tests_1}
+runtest ${prog} "--group-by 3-0 input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "--header --max 1 input_1field_a.tsv" ${error_tests_1}
 runtest ${prog} "-d abc --count input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "-d ß --count input_5field_a.tsv" ${error_tests_1}
@@ -138,3 +142,9 @@ runtest ${prog} "--quantile 3:0.5,2 input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "--quantile 0:0.5 input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "--quantile 3,4:0.75:q3 input_5field_a.tsv" ${error_tests_1}
 runtest ${prog} "--quantile 3:0.25,0.75:q1q3 input_5field_a.tsv" ${error_tests_1}
+runtest ${prog} "--quantile 3, input_5field_a.tsv" ${error_tests_1}
+runtest ${prog} "--quantile 3- input_5field_a.tsv" ${error_tests_1}
+runtest ${prog} "--quantile 0:0.25 input_5field_a.tsv" ${error_tests_1}
+runtest ${prog} "--quantile 1.5:0.25 input_5field_a.tsv" ${error_tests_1}
+runtest ${prog} "--quantile 1-:0.25 input_5field_a.tsv" ${error_tests_1}
+runtest ${prog} "--quantile -2:0.25 input_5field_a.tsv" ${error_tests_1}

--- a/tsv-uniq/tests/gold/basic_tests_1.txt
+++ b/tsv-uniq/tests/gold/basic_tests_1.txt
@@ -97,6 +97,25 @@ f1	f2	f3	f4	f5
 14	 	 	sp-sp	2022
 17	0	Z	5734	602
 
+====[tsv-uniq --header -f 1-5 input1.tsv]====
+f1	f2	f3	f4	f5
+1	ggg	UUU	101	15
+2	bbb	ZZZ	21	28
+3	ggg	CCC	5734	52
+4	ddd	ZZZ	65	602
+5	ßßß	SSS	 7	771
+6	sss	sss	17	15
+7	ssssss	sss	18	16
+8	àbc	P	1209	1234
+9	ÀBC		1367	1331
+10			e-e	1602
+11	0	X	1721	1703
+12	 	 	sp-sp	2020
+13	0.0	Z	1931	1956
+8	ÀBC	p	1209	1234
+14	 	 	sp-sp	2022
+17	0	Z	5734	602
+
 ====[tsv-uniq --header --ignore-case input1.tsv]====
 f1	f2	f3	f4	f5
 1	ggg	UUU	101	15
@@ -235,6 +254,24 @@ f1	f2	f3	f4	f5
 17	0	Z	5734	602
 
 ====[tsv-uniq input1.tsv --header -f 4,3]====
+f1	f2	f3	f4	f5
+1	ggg	UUU	101	15
+2	bbb	ZZZ	21	28
+3	ggg	CCC	5734	52
+4	ddd	ZZZ	65	602
+5	ßßß	SSS	 7	771
+6	sss	sss	17	15
+7	ssssss	sss	18	16
+8	àbc	P	1209	1234
+9	ÀBC		1367	1331
+10			e-e	1602
+11	0	X	1721	1703
+12	 	 	sp-sp	2020
+13	0.0	Z	1931	1956
+8	ÀBC	p	1209	1234
+17	0	Z	5734	602
+
+====[tsv-uniq input1.tsv --header -f 4-3]====
 f1	f2	f3	f4	f5
 1	ggg	UUU	101	15
 2	bbb	ZZZ	21	28

--- a/tsv-uniq/tests/gold/error_tests_1.txt
+++ b/tsv-uniq/tests/gold/error_tests_1.txt
@@ -4,6 +4,18 @@ Error test set 1
 ====[tsv-uniq -f 1,0 input1.tsv]====
 Error processing command line arguments: Whole line as key (--f|field 0) cannot be combined with multiple fields.
 
+====[tsv-uniq -f 1,g input1.tsv]====
+Error processing command line arguments: [--f|fields] Unexpected 'g' when converting from type string to type ulong
+
+====[tsv-uniq -f 1-g input1.tsv]====
+Error processing command line arguments: [--f|fields] Unexpected 'g' when converting from type string to type ulong
+
+====[tsv-uniq -f 0-2 input1.tsv]====
+Error processing command line arguments: [--f|fields] Zero cannot be used as part of a range: '0-2'
+
+====[tsv-uniq -f 1- input1.tsv]====
+Error processing command line arguments: [--f|fields] Incomplete ranges are not supported: '1-'
+
 ====[tsv-uniq -d abc -f 2 input1.tsv]====
 Error processing command line arguments: Unexpected 'b' when converting from type string to type char
 
@@ -17,4 +29,7 @@ Error processing command line arguments: --equiv-start requires --e|equiv
 Error processing command line arguments: --equiv-header requires --e|equiv
 
 ====[tsv-uniq -f 2,30 input1.tsv]====
+Error: Not enough fields in line. File: input1.tsv, Line: 1
+
+====[tsv-uniq -f 2-30 input1.tsv]====
 Error: Not enough fields in line. File: input1.tsv, Line: 1

--- a/tsv-uniq/tests/tests.sh
+++ b/tsv-uniq/tests/tests.sh
@@ -34,6 +34,7 @@ runtest ${prog} "--header input1.tsv" ${basic_tests_1}
 runtest ${prog} "-f 0 input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header -f 0 input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header -f 1,2,3,4,5 input1.tsv" ${basic_tests_1}
+runtest ${prog} "--header -f 1-5 input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header --ignore-case input1.tsv" ${basic_tests_1}
 runtest ${prog} "--ignore-case --equiv input1.tsv" ${basic_tests_1}
 runtest ${prog} "--header --equiv --ignore-case input1.tsv" ${basic_tests_1}
@@ -45,6 +46,7 @@ runtest ${prog} "input1.tsv --fields 1" ${basic_tests_1}
 runtest ${prog} "input1.tsv --header -f 2" ${basic_tests_1}
 runtest ${prog} "input1.tsv --header -f 3,4" ${basic_tests_1}
 runtest ${prog} "input1.tsv --header -f 4,3" ${basic_tests_1}
+runtest ${prog} "input1.tsv --header -f 4-3" ${basic_tests_1}
 runtest ${prog} "input1.tsv --header -f 3,4 --ignore-case" ${basic_tests_1}
 runtest ${prog} "input1.tsv --header -f 5" ${basic_tests_1}
 runtest ${prog} "input1.tsv --header -f 3,4 --equiv --ignore-case" ${basic_tests_1}
@@ -99,12 +101,17 @@ runtest ${prog} "-f 1,0 input1.tsv" ${error_tests_1}
 
 # Disable this test until Phobos 2.071 is available on all compilers
 # 2.071 changed the error message in a minor way.
-#runtest ${prog} "-f 1,g input1.tsv" ${error_tests_1}
+runtest ${prog} "-f 1,g input1.tsv" ${error_tests_1}
+
+runtest ${prog} "-f 1-g input1.tsv" ${error_tests_1}
+runtest ${prog} "-f 0-2 input1.tsv" ${error_tests_1}
+runtest ${prog} "-f 1- input1.tsv" ${error_tests_1}
 
 runtest ${prog} "-d abc -f 2 input1.tsv" ${error_tests_1}
 runtest ${prog} "-d ß -f 1 input1.tsv" ${error_tests_1}
 runtest ${prog} "-f 2 --equiv-start 10 input1.tsv" ${error_tests_1}
 runtest ${prog} "-f 2 --equiv-header abc input1.tsv" ${error_tests_1}
 runtest ${prog} "-f 2,30 input1.tsv" ${error_tests_1}
+runtest ${prog} "-f 2-30 input1.tsv" ${error_tests_1}
 
 exit $?


### PR DESCRIPTION
Adds support for field ranges as part of a field list. For example:
```
$ tsv-select --fields 1,2,17-35  data.tsv
```
Available anywhere a list of fields can be entered.