### PR TITLE
Add program name to error message text.

### DIFF
--- a/common/src/tsvutil.d
+++ b/common/src/tsvutil.d
@@ -996,6 +996,7 @@ unittest // parseFieldRange
     assertThrown("0".parseFieldRange!(size_t, Yes.convertToZeroBasedIndex));
     assertThrown("0-3".parseFieldRange!(size_t, Yes.convertToZeroBasedIndex));
     assertThrown("-2-4".parseFieldRange!(size_t, Yes.convertToZeroBasedIndex));
+    assertThrown("2--4".parseFieldRange!(size_t, Yes.convertToZeroBasedIndex));
 
     assertThrown("".parseFieldRange!(size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero));
     assertThrown(" ".parseFieldRange!(size_t, No.convertToZeroBasedIndex, Yes.allowFieldNumZero));

--- a/csv2tsv/tests/gold/error_tests_1.txt
+++ b/csv2tsv/tests/gold/error_tests_1.txt
@@ -2,17 +2,17 @@ Error test set 1
 ----------------
 
 ====[csv2tsv nosuchfile.txt]====
-Error: Cannot open file `nosuchfile.txt' in mode `rb' (No such file or directory)
+Error [csv2tsv]: Cannot open file `nosuchfile.txt' in mode `rb' (No such file or directory)
 
 
 ====[csv2tsv --nosuchparam input1.txt]====
-Error processing command line arguments: Unrecognized option --nosuchparam
+[csv2tsv] Error processing command line arguments: Unrecognized option --nosuchparam
 
 ====[csv2tsv -q x -c x input2.csv]====
-Error processing command line arguments: CSV quote and CSV field delimiter characters must be different (--q|quote, --c|csv-delim).
+[csv2tsv] Error processing command line arguments: CSV quote and CSV field delimiter characters must be different (--q|quote, --c|csv-delim).
 
 ====[csv2tsv -q x -t x input2.csv]====
-Error processing command line arguments: CSV quote and TSV field delimiter characters must be different (--q|quote, --t|tsv-delim).
+[csv2tsv] Error processing command line arguments: CSV quote and TSV field delimiter characters must be different (--q|quote, --t|tsv-delim).
 
 ====[csv2tsv -t x -r wxyz input2.csv]====
-Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|replacement).
+[csv2tsv] Error processing command line arguments: Replacement character cannot contain newlines or TSV field delimiters (--r|replacement).

--- a/number-lines/src/number-lines.d
+++ b/number-lines/src/number-lines.d
@@ -32,13 +32,14 @@ Examples:
 Options:
 EOS";
 
-/** 
-Container for command line options. 
+/**
+Container for command line options.
  */
 struct NumberLinesOptions
 {
     enum defaultHeaderString = "line";
-    
+
+    string programName;
     bool hasHeader = false;       // --H|header
     string headerString = "";     // --s|header-string
     long startNum = 1;            // --n|start-num
@@ -48,12 +49,15 @@ struct NumberLinesOptions
     /* Returns a tuple. First value is true if command line arguments were successfully
      * processed and execution should continue, or false if an error occurred or the user
      * asked for help. If false, the second value is the appropriate exit code (0 or 1).
-     */ 
+     */
     auto processArgs (ref string[] cmdArgs)
     {
         import std.algorithm : any, each;
         import std.getopt;
-        
+        import std.path : baseName, stripExtension;
+
+        programName = (cmdArgs.length > 0) ? cmdArgs[0].stripExtension.baseName : "Unknown_program_name";
+
         try
         {
             auto r = getopt(
@@ -87,11 +91,11 @@ struct NumberLinesOptions
         }
         catch (Exception exc)
         {
-            stderr.writeln("Error processing command line arguments: ", exc.msg);
+            stderr.writefln("[%s] Error processing command line arguments: %s", programName, exc.msg);
             return tuple(false, 1);
         }
         return tuple(true, 0);
-    }           
+    }
 }
 
 int main(string[] cmdArgs)
@@ -102,14 +106,14 @@ int main(string[] cmdArgs)
         import core.runtime : dmd_coverSetMerge;
         dmd_coverSetMerge(true);
     }
-    
+
     NumberLinesOptions cmdopt;
     auto r = cmdopt.processArgs(cmdArgs);
     if (!r[0]) return r[1];
     try numberLines(cmdopt, cmdArgs[1..$]);
     catch (Exception exc)
     {
-        stderr.writeln("Error: ", exc.msg);
+        stderr.writefln("Error [%s]: %s", cmdopt.programName, exc.msg);
         return 1;
     }
 
@@ -119,7 +123,7 @@ int main(string[] cmdArgs)
 void numberLines(in NumberLinesOptions cmdopt, in string[] inputFiles)
 {
     import std.range;
-    
+
     long lineNum = cmdopt.startNum;
     bool headerWritten = false;
     foreach (filename; (inputFiles.length > 0) ? inputFiles : ["-"])

--- a/number-lines/tests/gold/error_tests_1.txt
+++ b/number-lines/tests/gold/error_tests_1.txt
@@ -2,10 +2,10 @@ Error test set 1
 ----------------
 
 ====[number-lines nosuchfile.txt]====
-Error: Cannot open file `nosuchfile.txt' in mode `rb' (No such file or directory)
+Error [number-lines]: Cannot open file `nosuchfile.txt' in mode `rb' (No such file or directory)
 
 ====[number-lines -d ß input1.txt]====
-Error processing command line arguments: Invalid UTF-8 sequence (at index 1)
+[number-lines] Error processing command line arguments: Invalid UTF-8 sequence (at index 1)
 
 ====[number-lines --nosuchparam input1.txt]====
-Error processing command line arguments: Unrecognized option --nosuchparam
+[number-lines] Error processing command line arguments: Unrecognized option --nosuchparam

--- a/tsv-filter/src/tsv-filter.d
+++ b/tsv-filter/src/tsv-filter.d
@@ -11,7 +11,7 @@ License: Boost Licence 1.0 (http://boost.org/LICENSE_1_0.txt)
 */
 module tsv_filter;
 
-import std.algorithm : canFind, equal, findSplit, max, min; 
+import std.algorithm : canFind, equal, findSplit, max, min;
 import std.conv : to;
 import std.format : format;
 import std.math : abs, isFinite, isInfinity, isNaN;
@@ -36,14 +36,14 @@ int main(string[] cmdArgs)
         import core.runtime : dmd_coverSetMerge;
         dmd_coverSetMerge(true);
     }
-    
+
     TsvFilterOptions cmdopt;
     auto r = cmdopt.processArgs(cmdArgs);
     if (!r[0]) return r[1];
     try tsvFilter(cmdopt, cmdArgs[1..$]);
     catch (Exception exc)
     {
-        stderr.writeln("Error: ", exc.msg);
+        stderr.writefln("Error [%s]: %s", cmdopt.programName, exc.msg);
         return 1;
     }
     return 0;
@@ -71,7 +71,7 @@ Operators:
 
 * Test if a field is numeric, finite, NaN, or infinity
   Syntax:  --is-numeric|is-finite|is-nan|is-infinity FIELD
-  Example: --is-numeric 5 --gt 5:100  // Ensure field 5 is numeric before --gt test. 
+  Example: --is-numeric 5 --gt 5:100  // Ensure field 5 is numeric before --gt test.
 
 * Compare a field to a number (integer or float)
   Syntax:  --eq|ne|lt|le|gt|ge  FIELD:NUM
@@ -170,7 +170,7 @@ alias FieldsPredicate = bool delegate(const char[][] fields);
  * - FieldVsNumberPredicate - Test based on a field index (used to get the field value)
  *   and a fixed numeric value. For example, field 2 less than 100 (--lt 2:100).
  * - FieldVsStringPredicate - Test based on a field and a string. (e.g. --str-eq 2:abc)
- * - FieldVsIStringPredicate - Case-insensitive test based on a field and a string. 
+ * - FieldVsIStringPredicate - Case-insensitive test based on a field and a string.
  *   (e.g. --istr-eq 2:abc)
  * - FieldVsRegexPredicate - Test based on a field and a regex. (e.g. --regex '2:ab*c')
  * - FieldVsFieldPredicate - Test based on two fields. (e.g. --ff-le 2:4).
@@ -179,7 +179,7 @@ alias FieldsPredicate = bool delegate(const char[][] fields);
  * runs the test. For example, a function testing if a field is less than a specific
  * value would pull the specified field from the fields array, convert the string to
  * a number, then run the less-than test.
- */ 
+ */
 alias FieldUnaryPredicate    = bool function(const char[][] fields, size_t index);
 alias FieldVsNumberPredicate = bool function(const char[][] fields, size_t index, double value);
 alias FieldVsStringPredicate = bool function(const char[][] fields, size_t index, string value);
@@ -288,19 +288,19 @@ auto RelDiff(double v1, double v2) { return (v1 - v2).abs / min(v1.abs, v2.abs);
 
 bool ffAbsDiffLE(const char[][] fields, size_t index1, size_t index2, double value)
 {
-    return AbsDiff(fields[index1].to!double, fields[index2].to!double) <= value; 
+    return AbsDiff(fields[index1].to!double, fields[index2].to!double) <= value;
 }
 bool ffAbsDiffGT(const char[][] fields, size_t index1, size_t index2, double value)
 {
-    return AbsDiff(fields[index1].to!double, fields[index2].to!double) > value; 
+    return AbsDiff(fields[index1].to!double, fields[index2].to!double) > value;
 }
 bool ffRelDiffLE(const char[][] fields, size_t index1, size_t index2, double value)
 {
-    return RelDiff(fields[index1].to!double, fields[index2].to!double) <= value; 
+    return RelDiff(fields[index1].to!double, fields[index2].to!double) <= value;
 }
 bool ffRelDiffGT(const char[][] fields, size_t index1, size_t index2, double value)
 {
-    return RelDiff(fields[index1].to!double, fields[index2].to!double) > value; 
+    return RelDiff(fields[index1].to!double, fields[index2].to!double) > value;
 }
 
 /* Command line option handlers - There is a command line option handler for each
@@ -377,7 +377,7 @@ void fieldVsNumberOptionHandler(
     }
     size_t zeroBasedIndex = field - 1;
     tests ~= makeFieldVsNumberDelegate(fn, zeroBasedIndex, value);
-    maxFieldIndex = (zeroBasedIndex > maxFieldIndex) ? zeroBasedIndex : maxFieldIndex; 
+    maxFieldIndex = (zeroBasedIndex > maxFieldIndex) ? zeroBasedIndex : maxFieldIndex;
 }
 
 void fieldVsStringOptionHandler(
@@ -411,7 +411,7 @@ void fieldVsStringOptionHandler(
     }
     size_t zeroBasedIndex = field - 1;
     tests ~= makeFieldVsStringDelegate(fn, zeroBasedIndex, value);
-    maxFieldIndex = (zeroBasedIndex > maxFieldIndex) ? zeroBasedIndex : maxFieldIndex; 
+    maxFieldIndex = (zeroBasedIndex > maxFieldIndex) ? zeroBasedIndex : maxFieldIndex;
 }
 
 /* The fieldVsIStringOptionHandler lower-cases the command line argument, assuming the
@@ -448,7 +448,7 @@ void fieldVsIStringOptionHandler(
     }
     size_t zeroBasedIndex = field - 1;
     tests ~= makeFieldVsIStringDelegate(fn, zeroBasedIndex, value.to!dstring.toLower);
-    maxFieldIndex = (zeroBasedIndex > maxFieldIndex) ? zeroBasedIndex : maxFieldIndex; 
+    maxFieldIndex = (zeroBasedIndex > maxFieldIndex) ? zeroBasedIndex : maxFieldIndex;
 }
 
 void fieldVsRegexOptionHandler(
@@ -484,7 +484,7 @@ void fieldVsRegexOptionHandler(
     }
     size_t zeroBasedIndex = field - 1;
     tests ~= makeFieldVsRegexDelegate(fn, zeroBasedIndex, value);
-    maxFieldIndex = (zeroBasedIndex > maxFieldIndex) ? zeroBasedIndex : maxFieldIndex; 
+    maxFieldIndex = (zeroBasedIndex > maxFieldIndex) ? zeroBasedIndex : maxFieldIndex;
 }
 
 void fieldVsFieldOptionHandler(
@@ -516,13 +516,13 @@ void fieldVsFieldOptionHandler(
         throw new Exception(
             format("Invalid option: '--%s %s'. Zero is not a valid field index.", option, optionVal));
     }
-    
+
     if (field1 == field2)
     {
         throw new Exception(
             format("Invalid option: '--%s %s'. Field1 and field2 must be different fields", option, optionVal));
     }
-    
+
     size_t zeroBasedIndex1 = field1 - 1;
     size_t zeroBasedIndex2 = field2 - 1;
     tests ~= makeFieldVsFieldDelegate(fn, zeroBasedIndex1, zeroBasedIndex2);
@@ -575,7 +575,7 @@ void fieldFieldNumOptionHandler(
         throw new Exception(
             format("Invalid option: '--%s %s'. Field1 and field2 must be different fields", option, optionVal));
     }
-        
+
     size_t zeroBasedIndex1 = field1 - 1;
     size_t zeroBasedIndex2 = field2 - 1;
     tests ~= makeFieldFieldNumDelegate(fn, zeroBasedIndex1, zeroBasedIndex2, value);
@@ -587,6 +587,7 @@ void fieldFieldNumOptionHandler(
  */
 struct TsvFilterOptions
 {
+    string programName;
     FieldsPredicate[] tests;         // Derived from tests
     size_t maxFieldIndex;            // Derived from tests
     bool hasHeader = false;          // --H|header
@@ -603,12 +604,15 @@ struct TsvFilterOptions
      *
      * Returning true (execution continues) means args have been validated and the
      * tests array has been established.
-     */ 
+     */
     auto processArgs (ref string[] cmdArgs)
     {
         import std.getopt;
+        import std.path : baseName, stripExtension;
         import getopt_inorder;
-        
+
+        programName = (cmdArgs.length > 0) ? cmdArgs[0].stripExtension.baseName : "Unknown_program_name";
+
         /* Command option handlers - One handler for each option. These conform to the
          * getopt required handler signature, and separate knowledge the specific command
          * option text from the option processing.
@@ -622,14 +626,14 @@ struct TsvFilterOptions
         void handlerFldIsFinite(string option, string value)   { fieldUnaryOptionHandler(tests, maxFieldIndex, &fldIsFinite, option, value); }
         void handlerFldIsNaN(string option, string value)      { fieldUnaryOptionHandler(tests, maxFieldIndex, &fldIsNaN, option, value); }
         void handlerFldIsInfinity(string option, string value) { fieldUnaryOptionHandler(tests, maxFieldIndex, &fldIsInfinity, option, value); }
-        
+
         void handlerNumLE(string option, string value) { fieldVsNumberOptionHandler(tests, maxFieldIndex, &numLE, option, value); }
         void handlerNumLT(string option, string value) { fieldVsNumberOptionHandler(tests, maxFieldIndex, &numLT, option, value); }
         void handlerNumGE(string option, string value) { fieldVsNumberOptionHandler(tests, maxFieldIndex, &numGE, option, value); }
         void handlerNumGT(string option, string value) { fieldVsNumberOptionHandler(tests, maxFieldIndex, &numGT, option, value); }
         void handlerNumEQ(string option, string value) { fieldVsNumberOptionHandler(tests, maxFieldIndex, &numEQ, option, value); }
         void handlerNumNE(string option, string value) { fieldVsNumberOptionHandler(tests, maxFieldIndex, &numNE, option, value); }
-        
+
         void handlerStrLE(string option, string value) { fieldVsStringOptionHandler(tests, maxFieldIndex, &strLE, option, value); }
         void handlerStrLT(string option, string value) { fieldVsStringOptionHandler(tests, maxFieldIndex, &strLT, option, value); }
         void handlerStrGE(string option, string value) { fieldVsStringOptionHandler(tests, maxFieldIndex, &strGE, option, value); }
@@ -644,19 +648,19 @@ struct TsvFilterOptions
         void handlerIStrNE(string option, string value)       { fieldVsIStringOptionHandler(tests, maxFieldIndex, &istrNE,       option, value); }
         void handlerIStrInFld(string option, string value)    { fieldVsIStringOptionHandler(tests, maxFieldIndex, &istrInFld,    option, value); }
         void handlerIStrNotInFld(string option, string value) { fieldVsIStringOptionHandler(tests, maxFieldIndex, &istrNotInFld, option, value); }
-        
+
         void handlerRegexMatch(string option, string value)     { fieldVsRegexOptionHandler(tests, maxFieldIndex, &regexMatch,    option, value, true); }
         void handlerRegexNotMatch(string option, string value)  { fieldVsRegexOptionHandler(tests, maxFieldIndex, &regexNotMatch, option, value, true); }
         void handlerIRegexMatch(string option, string value)    { fieldVsRegexOptionHandler(tests, maxFieldIndex, &regexMatch,    option, value, false); }
         void handlerIRegexNotMatch(string option, string value) { fieldVsRegexOptionHandler(tests, maxFieldIndex, &regexNotMatch, option, value, false); }
-        
+
         void handlerFFLE(string option, string value) { fieldVsFieldOptionHandler(tests, maxFieldIndex, &ffLE, option, value); }
         void handlerFFLT(string option, string value) { fieldVsFieldOptionHandler(tests, maxFieldIndex, &ffLT, option, value); }
         void handlerFFGE(string option, string value) { fieldVsFieldOptionHandler(tests, maxFieldIndex, &ffGE, option, value); }
         void handlerFFGT(string option, string value) { fieldVsFieldOptionHandler(tests, maxFieldIndex, &ffGT, option, value); }
         void handlerFFEQ(string option, string value) { fieldVsFieldOptionHandler(tests, maxFieldIndex, &ffEQ, option, value); }
         void handlerFFNE(string option, string value) { fieldVsFieldOptionHandler(tests, maxFieldIndex, &ffNE, option, value); }
-        
+
         void handlerFFStrEQ(string option, string value)  { fieldVsFieldOptionHandler(tests, maxFieldIndex, &ffStrEQ,  option, value); }
         void handlerFFStrNE(string option, string value)  { fieldVsFieldOptionHandler(tests, maxFieldIndex, &ffStrNE,  option, value); }
         void handlerFFIStrEQ(string option, string value) { fieldVsFieldOptionHandler(tests, maxFieldIndex, &ffIStrEQ, option, value); }
@@ -683,7 +687,7 @@ struct TsvFilterOptions
                 "v|invert",        "     Invert the filter, printing lines that do not match.", &invert,
                 std.getopt.config.caseInsensitive,
                 "d|delimiter",     "CHR  Field delimiter. Default: TAB. (Single byte UTF-8 characters only.)", &delim,
-                
+
                 "empty",           "FIELD       True if field is empty.", &handlerFldEmpty,
                 "not-empty",       "FIELD       True if field is not empty.", &handlerFldNotEmpty,
                 "blank",           "FIELD       True if field is empty or all whitespace.", &handlerFldBlank,
@@ -693,14 +697,14 @@ struct TsvFilterOptions
                 "is-finite",       "FIELD       True if field is interpretable as a number and is not NaN or infinity.", &handlerFldIsFinite,
                 "is-nan",          "FIELD       True if field is NaN.", &handlerFldIsNaN,
                 "is-infinity",     "FIELD       True if field is infinity.", &handlerFldIsInfinity,
-                
+
                 "le",              "FIELD:NUM   FIELD <= NUM (numeric).", &handlerNumLE,
                 "lt",              "FIELD:NUM   FIELD <  NUM (numeric).", &handlerNumLT,
                 "ge",              "FIELD:NUM   FIELD >= NUM (numeric).", &handlerNumGE,
                 "gt",              "FIELD:NUM   FIELD >  NUM (numeric).", &handlerNumGT,
                 "eq",              "FIELD:NUM   FIELD == NUM (numeric).", &handlerNumEQ,
                 "ne",              "FIELD:NUM   FIELD != NUM (numeric).", &handlerNumNE,
-                
+
                 "str-le",          "FIELD:STR   FIELD <= STR (string).", &handlerStrLE,
                 "str-lt",          "FIELD:STR   FIELD <  STR (string).", &handlerStrLT,
                 "str-ge",          "FIELD:STR   FIELD >= STR (string).", &handlerStrGE,
@@ -714,17 +718,17 @@ struct TsvFilterOptions
                 "str-not-in-fld",  "FIELD:STR   FIELD does not contain STR (substring search).", &handlerStrNotInFld,
                 "istr-not-in-fld", "FIELD:STR   FIELD does not contain STR (substring search, case-insensitive).", &handlerIStrNotInFld,
 
-                "regex",           "FIELD:REGEX   FIELD matches regular expression.", &handlerRegexMatch, 
-                "iregex",          "FIELD:REGEX   FIELD matches regular expression, case-insensitive.", &handlerIRegexMatch, 
-                "not-regex",       "FIELD:REGEX   FIELD does not match regular expression.", &handlerRegexNotMatch, 
-                "not-iregex",      "FIELD:REGEX   FIELD does not match regular expression, case-insensitive.", &handlerIRegexNotMatch, 
-                
+                "regex",           "FIELD:REGEX   FIELD matches regular expression.", &handlerRegexMatch,
+                "iregex",          "FIELD:REGEX   FIELD matches regular expression, case-insensitive.", &handlerIRegexMatch,
+                "not-regex",       "FIELD:REGEX   FIELD does not match regular expression.", &handlerRegexNotMatch,
+                "not-iregex",      "FIELD:REGEX   FIELD does not match regular expression, case-insensitive.", &handlerIRegexNotMatch,
+
                 "ff-le",           "FIELD1:FIELD2   FIELD1 <= FIELD2 (numeric).", &handlerFFLE,
                 "ff-lt",           "FIELD1:FIELD2   FIELD1 <  FIELD2 (numeric).", &handlerFFLT,
                 "ff-ge",           "FIELD1:FIELD2   FIELD1 >= FIELD2 (numeric).", &handlerFFGE,
                 "ff-gt",           "FIELD1:FIELD2   FIELD1 >  FIELD2 (numeric).", &handlerFFGT,
                 "ff-eq",           "FIELD1:FIELD2   FIELD1 == FIELD2 (numeric).", &handlerFFEQ,
-                "ff-ne",           "FIELD1:FIELD2   FIELD1 != FIELD2 (numeric).", &handlerFFNE,                
+                "ff-ne",           "FIELD1:FIELD2   FIELD1 != FIELD2 (numeric).", &handlerFFNE,
                 "ff-str-eq",       "FIELD1:FIELD2   FIELD1 == FIELD2 (string).", &handlerFFStrEQ,
                 "ff-istr-eq",      "FIELD1:FIELD2   FIELD1 == FIELD2 (string, case-insensitive).", &handlerFFIStrEQ,
                 "ff-str-ne",       "FIELD1:FIELD2   FIELD1 != FIELD2 (string).", &handlerFFStrNE,
@@ -741,7 +745,7 @@ struct TsvFilterOptions
              */
             if (r.helpWanted)
             {
-                stdout.write(helpText); 
+                stdout.write(helpText);
                 return tuple(false, 0);
             }
             else if (helpVerbose)
@@ -763,7 +767,7 @@ struct TsvFilterOptions
         }
         catch (Exception exc)
         {
-            stderr.writeln("Error processing command line arguments: ", exc.msg);
+            stderr.writefln("[%s] Error processing command line arguments: %s", programName, exc.msg);
             return tuple(false, 1);
         }
         return tuple(true, 0);
@@ -804,7 +808,7 @@ void tsvFilter(in TsvFilterOptions cmdopt, in string[] inputFiles)
                     fieldIndex++;
                     lineFields[fieldIndex] = fieldValue;
                 }
-                
+
                 if (fieldIndex == -1)
                 {
                     assert(line.length == 0);
@@ -823,13 +827,13 @@ void tsvFilter(in TsvFilterOptions cmdopt, in string[] inputFiles)
                         format("Not enough fields in line. File: %s, Line: %s",
                                (filename == "-") ? "Standard Input" : filename, lineNum));
                 }
-                
+
                 /* Run the tests. Tests will fail (throw) if a field cannot be converted
                  * to the expected type.
                  */
                 try
                 {
-                    bool passed = cmdopt.disjunct ? 
+                    bool passed = cmdopt.disjunct ?
                         cmdopt.tests.any!(x => x(lineFields)) :
                         cmdopt.tests.all!(x => x(lineFields));
                     if (cmdopt.invert) passed = !passed;

--- a/tsv-filter/tests/gold/error_tests_1.txt
+++ b/tsv-filter/tests/gold/error_tests_1.txt
@@ -2,62 +2,62 @@ Error test set 1
 ----------------
 
 ====[tsv-filter --header --le 2:10 nosuchfile.tsv]====
-Error: Cannot open file `nosuchfile.tsv' in mode `rb' (No such file or directory)
+Error [tsv-filter]: Cannot open file `nosuchfile.tsv' in mode `rb' (No such file or directory)
 
 ====[tsv-filter --header --gt 0:10 input1.tsv]====
-Error processing command line arguments: Invalid option: '--gt 0:10'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: Invalid option: '--gt 0:10'. Zero is not a valid field index.
 
 ====[tsv-filter --header --lt -1:10 input1.tsv]====
-Error processing command line arguments: Missing value for argument --lt.
+[tsv-filter] Error processing command line arguments: Missing value for argument --lt.
 
 ====[tsv-filter --header --ne abc:15 input1.tsv]====
-Error processing command line arguments: Invalid numeric values in option: '--ne abc:15'. Expected: '--ne <field>:<val>' where <field> and <val> are numbers.
+[tsv-filter] Error processing command line arguments: Invalid numeric values in option: '--ne abc:15'. Expected: '--ne <field>:<val>' where <field> and <val> are numbers.
 
 ====[tsv-filter --header --eq 2:def input1.tsv]====
-Error processing command line arguments: Invalid numeric values in option: '--eq 2:def'. Expected: '--eq <field>:<val>' where <field> and <val> are numbers.
+[tsv-filter] Error processing command line arguments: Invalid numeric values in option: '--eq 2:def'. Expected: '--eq <field>:<val>' where <field> and <val> are numbers.
 
 ====[tsv-filter --header --le 1000:10 input1.tsv]====
-Error: Not enough fields in line. File: input1.tsv, Line: 2
+Error [tsv-filter]: Not enough fields in line. File: input1.tsv, Line: 2
 F1	F2	F3	F4
 
 ====[tsv-filter --header --empty 23g input1.tsv]====
-Error processing command line arguments: Invalid value in option: '--empty 23g'. Expected: '--empty <field>' where field is a 1-upped integer.
+[tsv-filter] Error processing command line arguments: Invalid value in option: '--empty 23g'. Expected: '--empty <field>' where field is a 1-upped integer.
 
 ====[tsv-filter --header --str-gt 0:abc input1.tsv]====
-Error processing command line arguments: Invalid option: '--str-gt 0:abc'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: Invalid option: '--str-gt 0:abc'. Zero is not a valid field index.
 
 ====[tsv-filter --header --str-lt -1:ABC input1.tsv]====
-Error processing command line arguments: Missing value for argument --str-lt.
+[tsv-filter] Error processing command line arguments: Missing value for argument --str-lt.
 
 ====[tsv-filter --header --str-ne abc:a22 input1.tsv]====
-Error processing command line arguments: Invalid values in option: '--str-ne abc:a22'. Expected: '--str-ne <field>:<val>' where <field> is a number and <val> a string.
+[tsv-filter] Error processing command line arguments: Invalid values in option: '--str-ne abc:a22'. Expected: '--str-ne <field>:<val>' where <field> is a number and <val> a string.
 
 ====[tsv-filter --header --str-eq 2.2:def input1.tsv]====
-Error processing command line arguments: Invalid values in option: '--str-eq 2.2:def'. Expected: '--str-eq <field>:<val>' where <field> is a number and <val> a string.
+[tsv-filter] Error processing command line arguments: Invalid values in option: '--str-eq 2.2:def'. Expected: '--str-eq <field>:<val>' where <field> is a number and <val> a string.
 
 ====[tsv-filter --header --regex z:^A[b|B]C$ input1.tsv]====
-Error processing command line arguments: Invalid values in option: '--regex z:^A[b|B]C$'. Expected: '--regex <field>:<val>' where <field> is a number and <val> is a regular expression.
+[tsv-filter] Error processing command line arguments: Invalid values in option: '--regex z:^A[b|B]C$'. Expected: '--regex <field>:<val>' where <field> is a number and <val> is a regular expression.
 
 ====[tsv-filter --header --iregex a:^A[b|B]C$ input1.tsv]====
-Error processing command line arguments: Invalid values in option: '--iregex a:^A[b|B]C$'. Expected: '--iregex <field>:<val>' where <field> is a number and <val> is a regular expression.
+[tsv-filter] Error processing command line arguments: Invalid values in option: '--iregex a:^A[b|B]C$'. Expected: '--iregex <field>:<val>' where <field> is a number and <val> is a regular expression.
 
 ====[tsv-filter --header --ff-gt 0:1 input1.tsv]====
-Error processing command line arguments: Invalid option: '--ff-gt 0:1'. Zero is not a valid field index.
+[tsv-filter] Error processing command line arguments: Invalid option: '--ff-gt 0:1'. Zero is not a valid field index.
 
 ====[tsv-filter --header --ff-lt -1:2 input1.tsv]====
-Error processing command line arguments: Missing value for argument --ff-lt.
+[tsv-filter] Error processing command line arguments: Missing value for argument --ff-lt.
 
 ====[tsv-filter --header --ff-ne abc:3 input1.tsv]====
-Error processing command line arguments: Invalid values in option: '--ff-ne abc:3'. Expected: '--ff-ne <field1>:<field2>' where fields are 1-upped integers.
+[tsv-filter] Error processing command line arguments: Invalid values in option: '--ff-ne abc:3'. Expected: '--ff-ne <field1>:<field2>' where fields are 1-upped integers.
 
 ====[tsv-filter --header --ff-eq 2.2:4 input1.tsv]====
-Error processing command line arguments: Invalid values in option: '--ff-eq 2.2:4'. Expected: '--ff-eq <field1>:<field2>' where fields are 1-upped integers.
+[tsv-filter] Error processing command line arguments: Invalid values in option: '--ff-eq 2.2:4'. Expected: '--ff-eq <field1>:<field2>' where fields are 1-upped integers.
 
 ====[tsv-filter --header --ff-le 2:3.1 input1.tsv]====
-Error processing command line arguments: Invalid values in option: '--ff-le 2:3.1'. Expected: '--ff-le <field1>:<field2>' where fields are 1-upped integers.
+[tsv-filter] Error processing command line arguments: Invalid values in option: '--ff-le 2:3.1'. Expected: '--ff-le <field1>:<field2>' where fields are 1-upped integers.
 
 ====[tsv-filter --header --ff-str-ne abc:3 input1.tsv]====
-Error processing command line arguments: Invalid values in option: '--ff-str-ne abc:3'. Expected: '--ff-str-ne <field1>:<field2>' where fields are 1-upped integers.
+[tsv-filter] Error processing command line arguments: Invalid values in option: '--ff-str-ne abc:3'. Expected: '--ff-str-ne <field1>:<field2>' where fields are 1-upped integers.
 
 ====[tsv-filter --header --ff-str-eq 2.2:4 input1.tsv]====
-Error processing command line arguments: Invalid values in option: '--ff-str-eq 2.2:4'. Expected: '--ff-str-eq <field1>:<field2>' where fields are 1-upped integers.
+[tsv-filter] Error processing command line arguments: Invalid values in option: '--ff-str-eq 2.2:4'. Expected: '--ff-str-eq <field1>:<field2>' where fields are 1-upped integers.

--- a/tsv-join/src/tsv-join.d
+++ b/tsv-join/src/tsv-join.d
@@ -63,6 +63,7 @@ EOS";
  */
 struct TsvJoinOptions
 {
+    string programName;
     string filterFile;               // --filter
     size_t[] keyFields;              // --key-fields
     size_t[] dataFields;             // --data-fields
@@ -92,8 +93,11 @@ struct TsvJoinOptions
     {
         import std.algorithm : any, each;
         import std.getopt;
+        import std.path : baseName, stripExtension;
         import std.typecons : Yes, No;
         import tsvutil :  makeFieldListOptionHandler;
+
+        programName = (cmdArgs.length > 0) ? cmdArgs[0].stripExtension.baseName : "Unknown_program_name";
 
         /* Handler for --write-all. Special handler so two values can be set. */
         void writeAllHandler(string option, string value)
@@ -156,7 +160,7 @@ struct TsvJoinOptions
         }
         catch (Exception exc)
         {
-            stderr.writeln("Error processing command line arguments: ", exc.msg);
+            stderr.writefln("[%s] Error processing command line arguments: %s", programName, exc.msg);
             return tuple(false, 1);
         }
         return tuple(true, 0);
@@ -279,7 +283,7 @@ int main(string[] cmdArgs)
     try tsvJoin(cmdopt, cmdArgs[1..$]);
     catch (Exception exc)
     {
-        stderr.writeln("Error: ", exc.msg);
+        stderr.writefln("Error [%s]: %s", cmdopt.programName, exc.msg);
         return 1;
     }
     return 0;

--- a/tsv-join/tests/gold/error_tests_1.txt
+++ b/tsv-join/tests/gold/error_tests_1.txt
@@ -4,94 +4,94 @@ Error test set 1
 ===Duplicate keys===
 
 ====[tsv-join --header -f input1.tsv -k 2 -a 0 input2.tsv]====
-Error: Duplicate keys with different append values (use --z|allow-duplicate-keys to ignore)
+Error [tsv-join]: Duplicate keys with different append values (use --z|allow-duplicate-keys to ignore)
    [key 1][values]: [ggg][1	ggg	UUU	101	15]
    [key 2][values]: [ggg][5	ggg	CCC	5734	52]
 
 ====[tsv-join --header -f input1.tsv -k 2 -a 4 input2.tsv]====
-Error: Duplicate keys with different append values (use --z|allow-duplicate-keys to ignore)
+Error [tsv-join]: Duplicate keys with different append values (use --z|allow-duplicate-keys to ignore)
    [key 1][values]: [ggg][101]
    [key 2][values]: [ggg][5734]
 
 ===Invalid field indicies===
 
 ====[tsv-join --header -f input1.tsv -k 6 input2.tsv]====
-Error: Not enough fields in line. File: input1.tsv, Line: 1
+Error [tsv-join]: Not enough fields in line. File: input1.tsv, Line: 1
 
 ====[tsv-join --header -f input1.tsv -k 4 -a 6 input2.tsv]====
-Error: Not enough fields in line. File: input1.tsv, Line: 1
+Error [tsv-join]: Not enough fields in line. File: input1.tsv, Line: 1
 
 ====[tsv-join --header -f input1.tsv -k 4 -d 6 input2.tsv]====
-Error: Not enough fields in line. File: input2.tsv, Line: 2
+Error [tsv-join]: Not enough fields in line. File: input2.tsv, Line: 2
 f1	f2	f3	f4	f5
 
 ===Missing filter file===
 
 ====[tsv-join --header -k 2 input2.tsv]====
-Error processing command line arguments: Required option --filter-file was not supplied.
+[tsv-join] Error processing command line arguments: Required option --filter-file was not supplied.
 
 ===Invalid Whole line and individual field combos===
 
 ====[tsv-join --header -f input1.tsv -k 2,0 input2.tsv]====
-Error processing command line arguments: Field 0 (whole line) cannot be combined with individual fields (non-zero).
+[tsv-join] Error processing command line arguments: Field 0 (whole line) cannot be combined with individual fields (non-zero).
 
 ====[tsv-join --header -f input1.tsv -k 0,2 input2.tsv]====
-Error processing command line arguments: Field 0 (whole line) cannot be combined with individual fields (non-zero).
+[tsv-join] Error processing command line arguments: Field 0 (whole line) cannot be combined with individual fields (non-zero).
 
 ====[tsv-join --header -f input1.tsv -k 2,3 -d 0,2 input2.tsv]====
-Error processing command line arguments: Field 0 (whole line) cannot be combined with individual fields (non-zero).
+[tsv-join] Error processing command line arguments: Field 0 (whole line) cannot be combined with individual fields (non-zero).
 
 ====[tsv-join --header -f input1.tsv -k 2,3 -d 2,0 input2.tsv]====
-Error processing command line arguments: Field 0 (whole line) cannot be combined with individual fields (non-zero).
+[tsv-join] Error processing command line arguments: Field 0 (whole line) cannot be combined with individual fields (non-zero).
 
 ====[tsv-join --header -f input1.tsv -k 2 -d 0 input2.tsv]====
-Error processing command line arguments: If either --k|key-field or --d|data-field is zero both must be zero.
+[tsv-join] Error processing command line arguments: If either --k|key-field or --d|data-field is zero both must be zero.
 
 ====[tsv-join --header -f input1.tsv -k 0 -d 2 input2.tsv]====
-Error processing command line arguments: If either --k|key-field or --d|data-field is zero both must be zero.
+[tsv-join] Error processing command line arguments: If either --k|key-field or --d|data-field is zero both must be zero.
 
 ===Different number of filter and data keys===
 
 ====[tsv-join --header -f input1.tsv -k 2 -d 2,3 input2.tsv]====
-Error processing command line arguments: Different number of --k|key-fields and --d|data-fields.
+[tsv-join] Error processing command line arguments: Different number of --k|key-fields and --d|data-fields.
 
 ====[tsv-join --header -f input1.tsv -k 2,3 -d 2 input2.tsv]====
-Error processing command line arguments: Different number of --k|key-fields and --d|data-fields.
+[tsv-join] Error processing command line arguments: Different number of --k|key-fields and --d|data-fields.
 
 ===Header prefix without header===
 
 ====[tsv-join --prefix -f input1.tsv -k 2 input1_ input2.tsv]====
-Error processing command line arguments: Use --header when using --p|prefix.
+[tsv-join] Error processing command line arguments: Use --header when using --p|prefix.
 
 ===Exclude with an append field===
 
 ====[tsv-join --header --exclude -a 3 -f input1.tsv -k 6 input2.tsv]====
-Error processing command line arguments: --e|exclude cannot be used with --a|append-fields.
+[tsv-join] Error processing command line arguments: --e|exclude cannot be used with --a|append-fields.
 
 ===Invalid write-all combinations===
 
 ====[tsv-join --header --write-all MISSING -f input1.tsv -k 2,3 input2.tsv]====
-Error processing command line arguments: Use --a|append-fields when using --w|write-all.
+[tsv-join] Error processing command line arguments: Use --a|append-fields when using --w|write-all.
 
 ====[tsv-join --header --write-all MISSING -a 0 -f input1.tsv -k 2,3 input2.tsv]====
-Error processing command line arguments: Cannot use '--a|append-fields 0' (whole line) when using --w|write-all.
+[tsv-join] Error processing command line arguments: Cannot use '--a|append-fields 0' (whole line) when using --w|write-all.
 
 ====[tsv-join --header --write-all MISSING -a 1 --exclude  -f input1.tsv -k 2,3 input2.tsv]====
-Error processing command line arguments: --e|exclude cannot be used with --a|append-fields.
+[tsv-join] Error processing command line arguments: --e|exclude cannot be used with --a|append-fields.
 
 ===Invalid field ranges===
 
 ====[tsv-join --header -f input1.tsv -k 2,x input2.tsv]====
-Error processing command line arguments: [--k|key-fields] Unexpected 'x' when converting from type string to type ulong
+[tsv-join] Error processing command line arguments: [--k|key-fields] Unexpected 'x' when converting from type string to type ulong
 
 ====[tsv-join --header -f input1.tsv -k 2,3 -d 2,1.5 input2.tsv]====
-Error processing command line arguments: [--d|data-fields] Unexpected '.' when converting from type string to type ulong
+[tsv-join] Error processing command line arguments: [--d|data-fields] Unexpected '.' when converting from type string to type ulong
 
 ====[tsv-join --header -f input1.tsv -k 2 -a 1- input2.tsv]====
-Error processing command line arguments: [--a|append-fields] Incomplete ranges are not supported: '1-'
+[tsv-join] Error processing command line arguments: [--a|append-fields] Incomplete ranges are not supported: '1-'
 
 ====[tsv-join --header -f input1.tsv -k 2,,4 input2.tsv]====
-Error processing command line arguments: [--k|key-fields] Empty field number.
+[tsv-join] Error processing command line arguments: [--k|key-fields] Empty field number.
 
 ====[tsv-join --header -f input1.tsv -k input2.tsv]====
-Error processing command line arguments: [--k|key-fields] Unexpected 'i' when converting from type string to type ulong
+[tsv-join] Error processing command line arguments: [--k|key-fields] Unexpected 'i' when converting from type string to type ulong

--- a/tsv-select/src/tsv-select.d
+++ b/tsv-select/src/tsv-select.d
@@ -56,6 +56,7 @@ struct TsvSelectOptions
     // The allowed values for the --rest option.
     enum RestOptionVal { none, first, last };
 
+    string programName;
     bool hasHeader = false;     // --H|header
     char delim = '\t';          // --d|delimiter
     size_t[] fields;            // --f|fields
@@ -77,8 +78,11 @@ struct TsvSelectOptions
     {
         import std.algorithm : any, each;
         import std.getopt;
+        import std.path : baseName, stripExtension;
         import std.typecons : Yes, No;
         import tsvutil :  makeFieldListOptionHandler;
+
+        programName = (cmdArgs.length > 0) ? cmdArgs[0].stripExtension.baseName : "Unknown_program_name";
 
         try
         {
@@ -119,7 +123,7 @@ struct TsvSelectOptions
         }
         catch (Exception exc)
         {
-            stderr.writeln("Error processing command line arguments: ", exc.msg);
+            stderr.writefln("[%s] Error processing command line arguments: %s", programName, exc.msg);
             return tuple(false, 1);
         }
         return tuple(true, 0);
@@ -165,7 +169,7 @@ int main(string[] cmdArgs)
     }
     catch (Exception exc)
     {
-        stderr.writeln("Error: ", exc.msg);
+        stderr.writefln("Error [%s]: %s", cmdopt.programName, exc.msg);
         return 1;
     }
 

--- a/tsv-select/tests/gold/error_tests_1.txt
+++ b/tsv-select/tests/gold/error_tests_1.txt
@@ -2,48 +2,48 @@ Error test set 1
 ----------------
 
 ====[tsv-select input1.tsv]====
-Error processing command line arguments: Required option --f|fields was not supplied.
+[tsv-select] Error processing command line arguments: Required option --f|fields was not supplied.
 
 ====[tsv-select input1.tsv --rest last]====
-Error processing command line arguments: Required option --f|fields was not supplied.
+[tsv-select] Error processing command line arguments: Required option --f|fields was not supplied.
 
 ====[tsv-select input1.tsv --fields last]====
-Error processing command line arguments: [--f|fields] Unexpected 'l' when converting from type string to type long
+[tsv-select] Error processing command line arguments: [--f|fields] Unexpected 'l' when converting from type string to type long
 
 ====[tsv-select -f 0 input1.tsv]====
-Error processing command line arguments: [--f|fields] Field numbers must be greater than zero: '0'
+[tsv-select] Error processing command line arguments: [--f|fields] Field numbers must be greater than zero: '0'
 
 ====[tsv-select input1.tsv -f 2 --rest elsewhere]====
-Error processing command line arguments: RestOptionVal does not have a member named 'elsewhere'
+[tsv-select] Error processing command line arguments: RestOptionVal does not have a member named 'elsewhere'
 
 ====[tsv-select -f 1 nosuchfile.tsv]====
-Error: Cannot open file `nosuchfile.tsv' in mode `rb' (No such file or directory)
+Error [tsv-select]: Cannot open file `nosuchfile.tsv' in mode `rb' (No such file or directory)
 
 ====[tsv-select -f 1,4 input_3plus_fields.tsv]====
-Error: Not enough fields in line. File: input_3plus_fields.tsv,  Line: 3
+Error [tsv-select]: Not enough fields in line. File: input_3plus_fields.tsv,  Line: 3
 1	101
 2	5734
 
 ====[tsv-select -d ß -f 1 input1.tsv]====
-Error processing command line arguments: Invalid UTF-8 sequence (at index 1)
+[tsv-select] Error processing command line arguments: Invalid UTF-8 sequence (at index 1)
 
 ====[tsv-select -f 1 --nosuchparam input1.tsv]====
-Error processing command line arguments: Unrecognized option --nosuchparam
+[tsv-select] Error processing command line arguments: Unrecognized option --nosuchparam
 
 ====[tsv-select -f 0-1 input1.tsv]====
-Error processing command line arguments: [--f|fields] Field numbers must be greater than zero: '0'
+[tsv-select] Error processing command line arguments: [--f|fields] Field numbers must be greater than zero: '0'
 
 ====[tsv-select -f 2- input1.tsv]====
-Error processing command line arguments: [--f|fields] Incomplete ranges are not supported: '2-'
+[tsv-select] Error processing command line arguments: [--f|fields] Incomplete ranges are not supported: '2-'
 
 ====[tsv-select -f 1,3- input1.tsv]====
-Error processing command line arguments: [--f|fields] Incomplete ranges are not supported: '3-'
+[tsv-select] Error processing command line arguments: [--f|fields] Incomplete ranges are not supported: '3-'
 
 ====[tsv-select -f input1.tsv]====
-Error processing command line arguments: [--f|fields] Unexpected 'i' when converting from type string to type long
+[tsv-select] Error processing command line arguments: [--f|fields] Unexpected 'i' when converting from type string to type long
 
 ====[tsv-select -f 1, input1.tsv]====
-Error processing command line arguments: [--f|fields] Empty field number.
+[tsv-select] Error processing command line arguments: [--f|fields] Empty field number.
 
 ====[tsv-select -f 1.1 input1.tsv]====
-Error processing command line arguments: [--f|fields] Unexpected '.' when converting from type string to type long
+[tsv-select] Error processing command line arguments: [--f|fields] Unexpected '.' when converting from type string to type long

--- a/tsv-summarize/src/tsv-summarize.d
+++ b/tsv-summarize/src/tsv-summarize.d
@@ -39,7 +39,7 @@ else
         try tsvSummarize(cmdopt, cmdArgs[1..$]);
         catch (Exception exc)
         {
-            stderr.writeln("Error: ", exc.msg);
+            stderr.writefln("Error [%s]: %s", cmdopt.programName, exc.msg);
             return 1;
         }
         return 0;
@@ -138,6 +138,8 @@ EOS";
  * process the command line.
  */
 struct TsvSummarizeOptions {
+    string programName;
+
     /* Options set directly by on the command line.. */
     size_t[] keyFields;                // -g, --group-by
     bool hasHeader = false;            // --header
@@ -163,9 +165,12 @@ struct TsvSummarizeOptions {
     auto processArgs (ref string[] cmdArgs) {
         import std.algorithm : any, each;
         import std.getopt;
-        import getopt_inorder;
+        import std.path : baseName, stripExtension;
         import std.typecons : Yes, No;
+        import getopt_inorder;
         import tsvutil :  makeFieldListOptionHandler;
+
+        programName = (cmdArgs.length > 0) ? cmdArgs[0].stripExtension.baseName : "Unknown_program_name";
 
         try
         {
@@ -237,7 +242,7 @@ struct TsvSummarizeOptions {
         }
         catch (Exception exc)
         {
-            stderr.writeln("Error processing command line arguments: ", exc.msg);
+            stderr.writefln("[%s] Error processing command line arguments: %s", programName, exc.msg);
             return tuple(false, 1);
         }
         return tuple(true, 0);

--- a/tsv-summarize/tests/gold/error_tests_1.txt
+++ b/tsv-summarize/tests/gold/error_tests_1.txt
@@ -2,110 +2,110 @@ Error test set 1
 ----------------
 
 ====[tsv-summarize --count no_such_file.tsv]====
-Error: Cannot open file `no_such_file.tsv' in mode `rb' (No such file or directory)
+Error [tsv-summarize]: Cannot open file `no_such_file.tsv' in mode `rb' (No such file or directory)
 
 ====[tsv-summarize --unique-count 0 input_5field_a.tsv]====
-Error processing command line arguments: [--unique-count] Field numbers must be greater than zero: '0'
+[tsv-summarize] Error processing command line arguments: [--unique-count] Field numbers must be greater than zero: '0'
 
 ====[tsv-summarize --unique-count 2, input_5field_a.tsv]====
-Error processing command line arguments: [--unique-count] Empty field number.
+[tsv-summarize] Error processing command line arguments: [--unique-count] Empty field number.
 
 ====[tsv-summarize --unique-count 2: input_5field_a.tsv]====
-Error processing command line arguments: Invalid option value: '--unique-count 2:'. Expected: '--unique-count <field-list>' or '--unique-count <field>:<header>'.
+[tsv-summarize] Error processing command line arguments: Invalid option value: '--unique-count 2:'. Expected: '--unique-count <field-list>' or '--unique-count <field>:<header>'.
 
 ====[tsv-summarize --unique-count 2,3:my_header input_5field_a.tsv]====
-Error processing command line arguments: [--unique-count] Invalid option: '--unique-count 2,3:my_header'. Cannot specify a custom header when using multiple fields.
+[tsv-summarize] Error processing command line arguments: [--unique-count] Invalid option: '--unique-count 2,3:my_header'. Cannot specify a custom header when using multiple fields.
 
 ====[tsv-summarize --unique-count 2-5:my_header input_5field_a.tsv]====
-Error processing command line arguments: [--unique-count] Invalid option: '--unique-count 2-5:my_header'. Cannot specify a custom header when using multiple fields.
+[tsv-summarize] Error processing command line arguments: [--unique-count] Invalid option: '--unique-count 2-5:my_header'. Cannot specify a custom header when using multiple fields.
 
 ====[tsv-summarize --retain 2:my_header input_5field_a.tsv]====
-Error processing command line arguments: [--retain] Invalid option: '--retain 2:my_header'. Operator does not support custom headers.
+[tsv-summarize] Error processing command line arguments: [--retain] Invalid option: '--retain 2:my_header'. Operator does not support custom headers.
 
 ====[tsv-summarize --unique-count x input_5field_a.tsv]====
-Error processing command line arguments: [--unique-count] Unexpected 'x' when converting from type string to type long
+[tsv-summarize] Error processing command line arguments: [--unique-count] Unexpected 'x' when converting from type string to type long
 
 ====[tsv-summarize --unique-count 2 input_5field_a.tsv input_1field_a.tsv]====
-Error: Not enough fields in line. File: input_1field_a.tsv, Line: 1
+Error [tsv-summarize]: Not enough fields in line. File: input_1field_a.tsv, Line: 1
 
 ====[tsv-summarize --group-by 1 input_5field_a.tsv]====
-Error processing command line arguments: At least one summary operator is required.
+[tsv-summarize] Error processing command line arguments: At least one summary operator is required.
 
 ====[tsv-summarize --group-by 0 --count input_5field_a.tsv]====
-Error processing command line arguments: [--g|group-by] Field numbers must be greater than zero: '0'
+[tsv-summarize] Error processing command line arguments: [--g|group-by] Field numbers must be greater than zero: '0'
 
 ====[tsv-summarize --group-by 0 input_5field_a.tsv]====
-Error processing command line arguments: [--g|group-by] Field numbers must be greater than zero: '0'
+[tsv-summarize] Error processing command line arguments: [--g|group-by] Field numbers must be greater than zero: '0'
 
 ====[tsv-summarize --group-by 2, input_5field_a.tsv]====
-Error processing command line arguments: [--g|group-by] Empty field number.
+[tsv-summarize] Error processing command line arguments: [--g|group-by] Empty field number.
 
 ====[tsv-summarize --group-by 2: input_5field_a.tsv]====
-Error processing command line arguments: [--g|group-by] Unexpected ':' when converting from type string to type long
+[tsv-summarize] Error processing command line arguments: [--g|group-by] Unexpected ':' when converting from type string to type long
 
 ====[tsv-summarize --group-by x input_5field_a.tsv]====
-Error processing command line arguments: [--g|group-by] Unexpected 'x' when converting from type string to type long
+[tsv-summarize] Error processing command line arguments: [--g|group-by] Unexpected 'x' when converting from type string to type long
 
 ====[tsv-summarize --group-by 2 --unique-count 1 input_5field_a.tsv input_1field_a.tsv]====
-Error: Not enough fields in line. File: input_1field_a.tsv, Line: 1
+Error [tsv-summarize]: Not enough fields in line. File: input_1field_a.tsv, Line: 1
 
 ====[tsv-summarize --group-by 1- input_5field_a.tsv]====
-Error processing command line arguments: [--g|group-by] Incomplete ranges are not supported: '1-'
+[tsv-summarize] Error processing command line arguments: [--g|group-by] Incomplete ranges are not supported: '1-'
 
 ====[tsv-summarize --group-by 3-0 input_5field_a.tsv]====
-Error processing command line arguments: [--g|group-by] Field numbers must be greater than zero: '0'
+[tsv-summarize] Error processing command line arguments: [--g|group-by] Field numbers must be greater than zero: '0'
 
 ====[tsv-summarize --header --max 1 input_1field_a.tsv]====
-Error: Could not process line or field: no digits seen
+Error [tsv-summarize]: Could not process line or field: no digits seen
   File: input_1field_a.tsv Line: 3
 
 ====[tsv-summarize -d abc --count input_5field_a.tsv]====
-Error processing command line arguments: Unexpected 'b' when converting from type string to type char
+[tsv-summarize] Error processing command line arguments: Unexpected 'b' when converting from type string to type char
 
 ====[tsv-summarize -d ß --count input_5field_a.tsv]====
-Error processing command line arguments: Invalid UTF-8 sequence (at index 1)
+[tsv-summarize] Error processing command line arguments: Invalid UTF-8 sequence (at index 1)
 
 ====[tsv-summarize -v abc --count input_5field_a.tsv]====
-Error processing command line arguments: Unexpected 'b' when converting from type string to type char
+[tsv-summarize] Error processing command line arguments: Unexpected 'b' when converting from type string to type char
 
 ====[tsv-summarize -v ß --count input_5field_a.tsv]====
-Error processing command line arguments: Invalid UTF-8 sequence (at index 1)
+[tsv-summarize] Error processing command line arguments: Invalid UTF-8 sequence (at index 1)
 
 ====[tsv-summarize --count --exclude-missing --replace-missing XYZ input_5field_a.tsv]====
-Error processing command line arguments: Cannot use both '--x|exclude-missing' and '--r|replace-missing'.
+[tsv-summarize] Error processing command line arguments: Cannot use both '--x|exclude-missing' and '--r|replace-missing'.
 
 ====[tsv-summarize --quantile 3 input_5field_a.tsv]====
-Error processing command line arguments: Invalid option value: '--quantile 3'. Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
+[tsv-summarize] Error processing command line arguments: Invalid option value: '--quantile 3'. Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
 
 ====[tsv-summarize --quantile 3:2 input_5field_a.tsv]====
-Error processing command line arguments: Invalid option: '--quantile 3:2'. Probability '2' is not in the interval [0.0,1.0].
+[tsv-summarize] Error processing command line arguments: Invalid option: '--quantile 3:2'. Probability '2' is not in the interval [0.0,1.0].
 
 ====[tsv-summarize --quantile 3:0.5,2 input_5field_a.tsv]====
-Error processing command line arguments: Invalid option: '--quantile 3:0.5,2'. Probability '2' is not in the interval [0.0,1.0].
+[tsv-summarize] Error processing command line arguments: Invalid option: '--quantile 3:0.5,2'. Probability '2' is not in the interval [0.0,1.0].
 
 ====[tsv-summarize --quantile 0:0.5 input_5field_a.tsv]====
-Error processing command line arguments: [--quantile] Field numbers must be greater than zero: '0'
+[tsv-summarize] Error processing command line arguments: [--quantile] Field numbers must be greater than zero: '0'
 
 ====[tsv-summarize --quantile 3,4:0.75:q3 input_5field_a.tsv]====
-Error processing command line arguments: Invalid option: '--quantile 3,4:0.75:q3'. Cannot specify a custom header when using multiple fields or multiple probabilities.
+[tsv-summarize] Error processing command line arguments: Invalid option: '--quantile 3,4:0.75:q3'. Cannot specify a custom header when using multiple fields or multiple probabilities.
 
 ====[tsv-summarize --quantile 3:0.25,0.75:q1q3 input_5field_a.tsv]====
-Error processing command line arguments: Invalid option: '--quantile 3:0.25,0.75:q1q3'. Cannot specify a custom header when using multiple fields or multiple probabilities.
+[tsv-summarize] Error processing command line arguments: Invalid option: '--quantile 3:0.25,0.75:q1q3'. Cannot specify a custom header when using multiple fields or multiple probabilities.
 
 ====[tsv-summarize --quantile 3, input_5field_a.tsv]====
-Error processing command line arguments: Invalid option value: '--quantile 3,'. Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
+[tsv-summarize] Error processing command line arguments: Invalid option value: '--quantile 3,'. Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
 
 ====[tsv-summarize --quantile 3- input_5field_a.tsv]====
-Error processing command line arguments: Invalid option value: '--quantile 3-'. Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
+[tsv-summarize] Error processing command line arguments: Invalid option value: '--quantile 3-'. Expected: '--quantile <field-list>:<prob>[,<prob>]' or '--quantile <field>:<prob>:<header>' where <prob> is a number between 0.0 and 1.0.
 
 ====[tsv-summarize --quantile 0:0.25 input_5field_a.tsv]====
-Error processing command line arguments: [--quantile] Field numbers must be greater than zero: '0'
+[tsv-summarize] Error processing command line arguments: [--quantile] Field numbers must be greater than zero: '0'
 
 ====[tsv-summarize --quantile 1.5:0.25 input_5field_a.tsv]====
-Error processing command line arguments: [--quantile] Unexpected '.' when converting from type string to type long
+[tsv-summarize] Error processing command line arguments: [--quantile] Unexpected '.' when converting from type string to type long
 
 ====[tsv-summarize --quantile 1-:0.25 input_5field_a.tsv]====
-Error processing command line arguments: [--quantile] Incomplete ranges are not supported: '1-'
+[tsv-summarize] Error processing command line arguments: [--quantile] Incomplete ranges are not supported: '1-'
 
 ====[tsv-summarize --quantile -2:0.25 input_5field_a.tsv]====
-Error processing command line arguments: Missing value for argument --quantile.
+[tsv-summarize] Error processing command line arguments: Missing value for argument --quantile.

--- a/tsv-uniq/src/tsv-uniq.d
+++ b/tsv-uniq/src/tsv-uniq.d
@@ -60,6 +60,7 @@ struct TsvUniqOptions
     enum defaultEquivHeader = "equiv_id";
     enum defaultEquivStartID = 1;
 
+    string programName;
     bool helpVerbose = false;                 // --help-verbose
     bool versionWanted = false;               // --V|version
     size_t[] fields;                          // --fields
@@ -83,8 +84,11 @@ struct TsvUniqOptions
     {
         import std.algorithm : any, each;
         import std.getopt;
+        import std.path : baseName, stripExtension;
         import std.typecons : Yes, No;
         import tsvutil :  makeFieldListOptionHandler;
+
+        programName = (cmdArgs.length > 0) ? cmdArgs[0].stripExtension.baseName : "Unknown_program_name";
 
         try
         {
@@ -158,7 +162,7 @@ struct TsvUniqOptions
         }
         catch (Exception exc)
         {
-            stderr.writeln("Error processing command line arguments: ", exc.msg);
+            stderr.writefln("[%s] Error processing command line arguments: %s", programName, exc.msg);
             return tuple(false, 1);
         }
         return tuple(true, 0);
@@ -180,7 +184,7 @@ int main(string[] cmdArgs)
     try tsvUniq(cmdopt, cmdArgs[1..$]);
     catch (Exception exc)
     {
-        stderr.writeln("Error: ", exc.msg);
+        stderr.writefln("Error [%s]: %s", cmdopt.programName, exc.msg);
         return 1;
     }
     return 0;

--- a/tsv-uniq/tests/gold/error_tests_1.txt
+++ b/tsv-uniq/tests/gold/error_tests_1.txt
@@ -2,34 +2,34 @@ Error test set 1
 ----------------
 
 ====[tsv-uniq -f 1,0 input1.tsv]====
-Error processing command line arguments: Whole line as key (--f|field 0) cannot be combined with multiple fields.
+[tsv-uniq] Error processing command line arguments: Whole line as key (--f|field 0) cannot be combined with multiple fields.
 
 ====[tsv-uniq -f 1,g input1.tsv]====
-Error processing command line arguments: [--f|fields] Unexpected 'g' when converting from type string to type ulong
+[tsv-uniq] Error processing command line arguments: [--f|fields] Unexpected 'g' when converting from type string to type ulong
 
 ====[tsv-uniq -f 1-g input1.tsv]====
-Error processing command line arguments: [--f|fields] Unexpected 'g' when converting from type string to type ulong
+[tsv-uniq] Error processing command line arguments: [--f|fields] Unexpected 'g' when converting from type string to type ulong
 
 ====[tsv-uniq -f 0-2 input1.tsv]====
-Error processing command line arguments: [--f|fields] Zero cannot be used as part of a range: '0-2'
+[tsv-uniq] Error processing command line arguments: [--f|fields] Zero cannot be used as part of a range: '0-2'
 
 ====[tsv-uniq -f 1- input1.tsv]====
-Error processing command line arguments: [--f|fields] Incomplete ranges are not supported: '1-'
+[tsv-uniq] Error processing command line arguments: [--f|fields] Incomplete ranges are not supported: '1-'
 
 ====[tsv-uniq -d abc -f 2 input1.tsv]====
-Error processing command line arguments: Unexpected 'b' when converting from type string to type char
+[tsv-uniq] Error processing command line arguments: Unexpected 'b' when converting from type string to type char
 
 ====[tsv-uniq -d ß -f 1 input1.tsv]====
-Error processing command line arguments: Invalid UTF-8 sequence (at index 1)
+[tsv-uniq] Error processing command line arguments: Invalid UTF-8 sequence (at index 1)
 
 ====[tsv-uniq -f 2 --equiv-start 10 input1.tsv]====
-Error processing command line arguments: --equiv-start requires --e|equiv
+[tsv-uniq] Error processing command line arguments: --equiv-start requires --e|equiv
 
 ====[tsv-uniq -f 2 --equiv-header abc input1.tsv]====
-Error processing command line arguments: --equiv-header requires --e|equiv
+[tsv-uniq] Error processing command line arguments: --equiv-header requires --e|equiv
 
 ====[tsv-uniq -f 2,30 input1.tsv]====
-Error: Not enough fields in line. File: input1.tsv, Line: 1
+Error [tsv-uniq]: Not enough fields in line. File: input1.tsv, Line: 1
 
 ====[tsv-uniq -f 2-30 input1.tsv]====
-Error: Not enough fields in line. File: input1.tsv, Line: 1
+Error [tsv-uniq]: Not enough fields in line. File: input1.tsv, Line: 1


### PR DESCRIPTION
Includes the program name in error text. This is useful when using tools in a pipeline. Clarifies which tool signaled the error.