### PR TITLE
Use LTO on LDC OS X builds (performance improvements)

### DIFF
--- a/csv2tsv/dub.json
+++ b/csv2tsv/dub.json
@@ -25,7 +25,7 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-ldc": ["-flto=full"] },
+                     "dflags-osx-ldc": ["-flto=full"] },
         "unittest" : { "buildOptions": ["unittests"] }
     }
 }

--- a/csv2tsv/dub.json
+++ b/csv2tsv/dub.json
@@ -23,7 +23,9 @@
     ],
     "buildTypes": {
         "debug": { "buildOptions": ["debugMode", "optimize"] },
-        "release": { "buildOptions": ["releaseMode", "optimize", "inline"], "dflags": ["-boundscheck=off"] },
+        "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
+                     "dflags": ["-boundscheck=off"],
+                     "dflags-ldc": ["-flto=full"] },
         "unittest" : { "buildOptions": ["unittests"] }
     }
 }

--- a/dub.json
+++ b/dub.json
@@ -48,6 +48,6 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-ldc": ["-flto=full"] }
+                     "dflags-osx-ldc": ["-flto=full"] }
     }
 }

--- a/dub.json
+++ b/dub.json
@@ -46,6 +46,8 @@
     ],
     "buildTypes": {
         "debug": { "buildOptions": ["debugMode", "optimize"] },
-        "release": { "buildOptions": ["releaseMode", "optimize", "inline"], "dflags": ["-boundscheck=off"] }
+        "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
+                     "dflags": ["-boundscheck=off"],
+                     "dflags-ldc": ["-flto=full"] }
     }
 }

--- a/keep-header/dub.json
+++ b/keep-header/dub.json
@@ -23,6 +23,8 @@
     ],
     "buildTypes": {
         "debug": { "buildOptions": ["debugMode", "optimize"] },
-        "release": { "buildOptions": ["releaseMode", "optimize", "inline"], "dflags": ["-boundscheck=off"] }
+        "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
+                     "dflags": ["-boundscheck=off"],
+                     "dflags-ldc": ["-flto=full"] }
     }
 }

--- a/keep-header/dub.json
+++ b/keep-header/dub.json
@@ -25,6 +25,6 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-ldc": ["-flto=full"] }
+                     "dflags-osx-ldc": ["-flto=full"] }
     }
 }

--- a/makedefs.mk
+++ b/makedefs.mk
@@ -4,12 +4,12 @@
 # 'common_srcs' variable, and includes the makeapp.mk include. See the app makefiles for
 # examples. The 'common' subdirectory makefile also includes this, but has it's own
 # makefile targets.
-# 
+#
 # This makefile can be customized by setting the DCOMPILER and DFLAGS variable. These
 # can also be set on the make command line.
 
 DCOMPILER = dmd
-DFLAGS = 
+DFLAGS =
 
 project_dir ?= $(realpath ..)
 common_srcdir = $(project_dir)/common/src
@@ -19,8 +19,8 @@ objdir = obj
 bindir = bin
 testsdir = tests
 
-release_flags_base = -release -O -boundscheck=off
-ifeq ($(DCOMPILER),dmd)
+release_flags_base = -release -O3 -boundscheck=off -singleobj -flto=full
+ifeq ($(notdir $(basename $(DCOMPILER))),dmd)
 	release_flags_base = -release -O -boundscheck=off -inline
 endif
 

--- a/makedefs.mk
+++ b/makedefs.mk
@@ -19,7 +19,14 @@ objdir = obj
 bindir = bin
 testsdir = tests
 
-release_flags_base = -release -O3 -boundscheck=off -singleobj -flto=full
+OS_NAME := $(shell uname -s)
+
+FLTO_OPTION =
+ifeq ($(OS_NAME),Darwin)
+	FLTO_OPTION = -flto=full
+endif
+
+release_flags_base = -release -O3 -boundscheck=off -singleobj $(FLTO_OPTION)
 ifeq ($(notdir $(basename $(DCOMPILER))),dmd)
 	release_flags_base = -release -O -boundscheck=off -inline
 endif

--- a/number-lines/dub.json
+++ b/number-lines/dub.json
@@ -23,6 +23,8 @@
     ],
     "buildTypes": {
         "debug": { "buildOptions": ["debugMode", "optimize"] },
-        "release": { "buildOptions": ["releaseMode", "optimize", "inline"], "dflags": ["-boundscheck=off"] }
+        "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
+                     "dflags": ["-boundscheck=off"],
+                     "dflags-ldc": ["-flto=full"] }
     }
 }

--- a/number-lines/dub.json
+++ b/number-lines/dub.json
@@ -25,6 +25,6 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-ldc": ["-flto=full"] }
+                     "dflags-osx-ldc": ["-flto=full"] }
     }
 }

--- a/tsv-append/dub.json
+++ b/tsv-append/dub.json
@@ -23,6 +23,8 @@
     ],
     "buildTypes": {
         "debug": { "buildOptions": ["debugMode", "optimize"] },
-        "release": { "buildOptions": ["releaseMode", "optimize", "inline"], "dflags": ["-boundscheck=off"] }
+        "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
+                     "dflags": ["-boundscheck=off"],
+                     "dflags-ldc": ["-flto=full"] }
     }
 }

--- a/tsv-append/dub.json
+++ b/tsv-append/dub.json
@@ -25,6 +25,6 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-ldc": ["-flto=full"] }
+                     "dflags-osx-ldc": ["-flto=full"] }
     }
 }

--- a/tsv-filter/dub.json
+++ b/tsv-filter/dub.json
@@ -24,6 +24,8 @@
     ],
     "buildTypes": {
         "debug": { "buildOptions": ["debugMode", "optimize"] },
-        "release": { "buildOptions": ["releaseMode", "optimize", "inline"], "dflags": ["-boundscheck=off"] }
+        "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
+                     "dflags": ["-boundscheck=off"],
+                     "dflags-ldc": ["-flto=full"] }
     }
 }

--- a/tsv-filter/dub.json
+++ b/tsv-filter/dub.json
@@ -26,6 +26,6 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-ldc": ["-flto=full"] }
+                     "dflags-osx-ldc": ["-flto=full"] }
     }
 }

--- a/tsv-join/dub.json
+++ b/tsv-join/dub.json
@@ -23,6 +23,8 @@
     ],
     "buildTypes": {
         "debug": { "buildOptions": ["debugMode", "optimize"] },
-        "release": { "buildOptions": ["releaseMode", "optimize", "inline"], "dflags": ["-boundscheck=off"] }
+        "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
+                     "dflags": ["-boundscheck=off"],
+                     "dflags-ldc": ["-flto=full"] }
     }
 }

--- a/tsv-join/dub.json
+++ b/tsv-join/dub.json
@@ -25,6 +25,6 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-ldc": ["-flto=full"] }
+                     "dflags-osx-ldc": ["-flto=full"] }
     }
 }

--- a/tsv-sample/dub.json
+++ b/tsv-sample/dub.json
@@ -23,6 +23,8 @@
     ],
     "buildTypes": {
         "debug": { "buildOptions": ["debugMode", "optimize"] },
-        "release": { "buildOptions": ["releaseMode", "optimize", "inline"], "dflags": ["-boundscheck=off"] }
+        "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
+                     "dflags": ["-boundscheck=off"],
+                     "dflags-ldc": ["-flto=full"] }
     }
 }

--- a/tsv-sample/dub.json
+++ b/tsv-sample/dub.json
@@ -25,6 +25,6 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-ldc": ["-flto=full"] }
+                     "dflags-osx-ldc": ["-flto=full"] }
     }
 }

--- a/tsv-select/dub.json
+++ b/tsv-select/dub.json
@@ -24,6 +24,8 @@
     ],
     "buildTypes": {
         "debug": { "buildOptions": ["debugMode", "optimize"] },
-        "release": { "buildOptions": ["releaseMode", "optimize", "inline"], "dflags": ["-boundscheck=off"] }
+        "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
+                     "dflags": ["-boundscheck=off"],
+                     "dflags-ldc": ["-flto=full"] }
     }
 }

--- a/tsv-select/dub.json
+++ b/tsv-select/dub.json
@@ -26,6 +26,6 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-ldc": ["-flto=full"] }
+                     "dflags-osx-ldc": ["-flto=full"] }
     }
 }

--- a/tsv-summarize/dub.json
+++ b/tsv-summarize/dub.json
@@ -23,6 +23,8 @@
     ],
     "buildTypes": {
         "debug": { "buildOptions": ["debugMode", "optimize"] },
-        "release": { "buildOptions": ["releaseMode", "optimize", "inline"], "dflags": ["-boundscheck=off"] }
+        "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
+                     "dflags": ["-boundscheck=off"],
+                     "dflags-ldc": ["-flto=full"] }
     }
 }

--- a/tsv-summarize/dub.json
+++ b/tsv-summarize/dub.json
@@ -25,6 +25,6 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-ldc": ["-flto=full"] }
+                     "dflags-osx-ldc": ["-flto=full"] }
     }
 }

--- a/tsv-uniq/dub.json
+++ b/tsv-uniq/dub.json
@@ -23,6 +23,8 @@
     ],
     "buildTypes": {
         "debug": { "buildOptions": ["debugMode", "optimize"] },
-        "release": { "buildOptions": ["releaseMode", "optimize", "inline"], "dflags": ["-boundscheck=off"] }
+        "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
+                     "dflags": ["-boundscheck=off"],
+                     "dflags-ldc": ["-flto=full"] }
     }
 }

--- a/tsv-uniq/dub.json
+++ b/tsv-uniq/dub.json
@@ -25,6 +25,6 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-ldc": ["-flto=full"] }
+                     "dflags-osx-ldc": ["-flto=full"] }
     }
 }


### PR DESCRIPTION
Use `-flto=full` on OS X when using LDC. This results in meaningful performance improvements in the `csv2tsv` tool, and possibly other tools as well.

Currently only setup on Mac OS X, which has LTO support in the system linker. Linux currently requires building the LLVM gold plugin. This complicates the build process.