### PR TITLE
Use thin lto

### DIFF
--- a/csv2tsv/dub.json
+++ b/csv2tsv/dub.json
@@ -25,7 +25,7 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-osx-ldc": ["-flto=full"] },
+                     "dflags-osx-ldc": ["-flto=thin"] },
         "unittest" : { "buildOptions": ["unittests"] }
     }
 }

--- a/dub.json
+++ b/dub.json
@@ -48,6 +48,6 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-osx-ldc": ["-flto=full"] }
+                     "dflags-osx-ldc": ["-flto=thin"] }
     }
 }

--- a/keep-header/dub.json
+++ b/keep-header/dub.json
@@ -25,6 +25,6 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-osx-ldc": ["-flto=full"] }
+                     "dflags-osx-ldc": ["-flto=thin"] }
     }
 }

--- a/makedefs.mk
+++ b/makedefs.mk
@@ -23,7 +23,7 @@ OS_NAME := $(shell uname -s)
 
 FLTO_OPTION =
 ifeq ($(OS_NAME),Darwin)
-	FLTO_OPTION = -flto=full
+	FLTO_OPTION = -flto=thin
 endif
 
 release_flags_base = -release -O3 -boundscheck=off -singleobj $(FLTO_OPTION)

--- a/number-lines/dub.json
+++ b/number-lines/dub.json
@@ -25,6 +25,6 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-osx-ldc": ["-flto=full"] }
+                     "dflags-osx-ldc": ["-flto=thin"] }
     }
 }

--- a/tsv-append/dub.json
+++ b/tsv-append/dub.json
@@ -25,6 +25,6 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-osx-ldc": ["-flto=full"] }
+                     "dflags-osx-ldc": ["-flto=thin"] }
     }
 }

--- a/tsv-filter/dub.json
+++ b/tsv-filter/dub.json
@@ -26,6 +26,6 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-osx-ldc": ["-flto=full"] }
+                     "dflags-osx-ldc": ["-flto=thin"] }
     }
 }

--- a/tsv-join/dub.json
+++ b/tsv-join/dub.json
@@ -25,6 +25,6 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-osx-ldc": ["-flto=full"] }
+                     "dflags-osx-ldc": ["-flto=thin"] }
     }
 }

--- a/tsv-sample/dub.json
+++ b/tsv-sample/dub.json
@@ -25,6 +25,6 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-osx-ldc": ["-flto=full"] }
+                     "dflags-osx-ldc": ["-flto=thin"] }
     }
 }

--- a/tsv-select/dub.json
+++ b/tsv-select/dub.json
@@ -26,6 +26,6 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-osx-ldc": ["-flto=full"] }
+                     "dflags-osx-ldc": ["-flto=thin"] }
     }
 }

--- a/tsv-summarize/dub.json
+++ b/tsv-summarize/dub.json
@@ -25,6 +25,6 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-osx-ldc": ["-flto=full"] }
+                     "dflags-osx-ldc": ["-flto=thin"] }
     }
 }

--- a/tsv-uniq/dub.json
+++ b/tsv-uniq/dub.json
@@ -25,6 +25,6 @@
         "debug": { "buildOptions": ["debugMode", "optimize"] },
         "release": { "buildOptions": ["releaseMode", "optimize", "inline"],
                      "dflags": ["-boundscheck=off"],
-                     "dflags-osx-ldc": ["-flto=full"] }
+                     "dflags-osx-ldc": ["-flto=thin"] }
     }
 }


### PR DESCRIPTION
LDC 1.3 with `-flto=full` has occasional failures during exception handling. Occurs in `tsv-filter` when handling bad `--regex` options. Using `-flto=thin` avoids this. It also generates faster executables for several of the apps