### PR TITLE
Temporarily use LDC 1.2 on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 osx_image: xcode8.2
 language: d
 d:
-- ldc
+- ldc-1.2.0
 - dmd
 script:
 - dub run -- --compiler=$DC


### PR DESCRIPTION
Avoids performance regression in versions 1.3, 1.4. See: https://github.com/ldc-developers/ldc/issues/2168