### PR TITLE
Enable LDC runtime LTO support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,63 +1,117 @@
-sudo: false
-os:
-- linux
-- osx
-osx_image: xcode9
-language: d
-d:
-- dmd
-- ldc-1.5.0-beta1
-env:
-- LTO=default
-- LTO=runtime
+# Tests:
+#   DUBTEST - dub build and test
+#   MAKETEST - make test, plus -static on LDC
+#   CODECOV - Runs code coverage
+#   APPLTO=[default|off|thin|full] - make test with the setting
+#   ALLLTO=[default|thin|full] - make test LDC_RUNTIME_LTO=1 and LTO value
+#   DOCKERSPECIAL - Special dockerized build to run LDC with LTO and -static
+#   DEPLOY - Deploy if a tagged release.
 matrix:
-  exclude:
-  - d: dmd
-    env: LTO=runtime
+  include:
+    - os: osx
+      osx_image: xcode9
+      language: d
+      d: dmd
+      env: DUBTEST=1 MAKETEST=1 CODECOV=1
+    - os: linux
+      language: d
+      d: dmd
+      env: DUBTEST=1 MAKETEST=1
+    - os: osx
+      osx_image: xcode9
+      language: d
+      d: ldc-1.2.0
+      env: DUBTEST=1 MAKETEST=1 APPLTO=off
+    - os: osx
+      osx_image: xcode9
+      language: d
+      d: ldc-1.5.0
+      env: DUBTEST=1 MAKETEST=1 APPLTO=off
+    - os: osx
+      osx_image: xcode9
+      language: d
+      d: ldc-1.5.0
+      env: ALLLTO=default DEPLOY=1
+    - os: linux
+      language: d
+      d: ldc-1.2.0
+      env: DUBTEST=1 MAKETEST=1
+    - os: linux
+      language: d
+      d: ldc-1.5.0
+      env: DUBTEST=1 MAKETEST=1 APPLTO=default
+    - os: linux
+      language: d
+      d: ldc-1.5.0
+      env: ALLLTO=default
+    - os: linux
+      dist: trusty
+      sudo: required
+      language: d
+      d: ldc-1.5.0
+      services: docker
+      env: DOCKERSPECIAL=1 DEPLOY=1
+before_install:
+  - if [[ "$DOCKERSPECIAL" == "1" ]]; then
+      sudo apt-get -qq update;
+      sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce;
+      docker pull dlanguage/ldc;
+      export UID=$(id -u);
+      export GID=$(id -g);
+    fi
 script:
-- if [[ "$LTO" == "default" ]]; then
+- if [[ "$DUBTEST" == "1" ]]; then
     dub run -- --compiler=$DC;
     make test-nobuild;
     dub clean;
     make clean;
-    make test DCOMPILER=$DC;
   fi
-- if [[ "$LTO" == "default" &&  "$DC" == "dmd" && "$TRAVIS_OS_NAME" == "osx" ]]; then
+- if [[ "$MAKETEST" == "1" ]]; then
+    make test DCOMPILER=$DC;
     make clean;
+    if [[ "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" ]]; then
+      make test DCOMPILER=$DC DFLAGS=-static;
+      make clean;
+    fi
+  fi
+- if [[ "$CODECOV" == "1" ]]; then
     make test-codecov;
   fi
-- if [[ "$LTO" == "default" && "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" ]]; then
+- if [[ ! -z "$APPLTO" ]]; then
+    make DCOMPILER=$DC LDC_LTO=$APPLTO;
     make clean;
-    make test DCOMPILER=$DC;
-    make clean;
-    make test DCOMPILER=$DC LDC_LTO=full;
-    make clean;
-    make test DCOMPILER=$DC DFLAGS=-static LDC_LTO=off;
   fi
-- if [[ "$LTO" == "runtime" && "$DC" == "ldc2" ]]; then
+- if [[ ! -z "$ALLLTO" ]]; then
+    if [[ "$ALLLTO" == "default" ]]; then
+      make DCOMPILER=$DC LDC_RUNTIME_LTO=1;
+    else
+      make DCOMPILER=$DC LDC_RUNTIME_LTO=1 LDC_LTO=$ALLLTO;
+    fi
     make clean;
-    make test DCOMPILER=$DC LDC_BUILD_RUNTIME=1;
+  fi
+- if [[ "$DOCKERSPECIAL" == "1" ]]; then
+    #docker run --rm -ti -v $(pwd):/src dlanguage/ldc make test DCOMPILER=$DC LDC_RUNTIME_LTO=1 DFLAGS=-static;
+    docker run --rm -ti -v $(pwd):/src dlanguage/ldc make test DCOMPILER=$DC;
+    sudo chown -R $UID:$GID $(pwd);
+    make test-nobuild;
+    make clean;
   fi
 after_success:
-- if [[ "$LTO" == "default" &&  "$DC" == "dmd" && "$TRAVIS_OS_NAME" == "osx" ]]; then
+- if [[ "$CODECOV" == "1" ]]; then
     bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports";
   fi
 before_deploy:
 - if [[ -z "$TRAVIS_TAG" || "$TRAVIS_TAG" == "" ]]; then
     export USE_VERSION="v~dev";
+  else export
+    USE_VERSION="$TRAVIS_TAG";
+  fi
+- if [[ "$DOCKERSPECIAL" == "1" ]]; then
+    docker run --rm -ti -v $(pwd):/src dlanguage/ldc make package DCOMPILER=$DC OS=$TRAVIS_OS_NAME APP_VERSION=$USE_VERSION LDC_RUNTIME_LTO=1 DFLAGS=-static;
+    sudo chown -R $UID:$GID $(pwd);
   else
-    export USE_VERSION="$TRAVIS_TAG";
+    make package DCOMPILER=$DC OS=$TRAVIS_OS_NAME APP_VERSION=$USE_VERSION LDC_RUNTIME_LTO=1;
   fi
-- if [[ "$LTO" == "runtime" ]]; then
-    export LDC_BUILD_RUNTIME_FLAG=1;
-    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      export OS_NAME_SUFFIX=-lto;
-    fi
-  elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    export DFLAGS_STATIC=-static;
-    export OS_NAME_SUFFIX=-staticlib;
-  fi
-- make package DCOMPILER=$DC OS=${TRAVIS_OS_NAME}${OS_NAME_SUFFIX} APP_VERSION=$USE_VERSION LDC_BUILD_RUNTIME=$LDC_BUILD_RUNTIME_FLAG DFLAGS=$DFLAGS_STATIC
 deploy:
   provider: releases
   api_key:
@@ -68,4 +122,4 @@ deploy:
   on:
     tags: true
     repo: eBay/tsv-utils-dlang
-    condition: "$DC = ldc2"
+    condition: "$DEPLOY = 1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ script:
 - make clean
 - make test DCOMPILER=$DC
 - if [[ "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" ]]; then make clean; make test DCOMPILER=$DC DFLAGS=-static; fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" ]]; then make clean; make test DCOMPILER=$DC LDC_BUILD_RUNTIME=1 DFLAGS=-static; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" && "$DC" == "ldc2" ]]; then make clean; make test DCOMPILER=$DC LDC_BUILD_RUNTIME=1; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" ]]; then make clean; make test DCOMPILER=$DC LDC_BUILD_RUNTIME=ldc-build-runtime DFLAGS=-static; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" && "$DC" == "ldc2" ]]; then make clean; make test DCOMPILER=$DC LDC_BUILD_RUNTIME=ldc-build-runtime; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" && "$DC" == "dmd" ]]; then make test-codecov; fi
 after_success:
 - if [[ "$TRAVIS_OS_NAME" == "osx" && "$DC" == "dmd" ]]; then bash <(curl -s https://codecov.io/bash)  ||

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,9 @@ script:
 - if [[ "$LTO" == "default" && "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" ]]; then
     make clean;
     make test DCOMPILER=$DC;
+    make clean;
     make test DCOMPILER=$DC LDC_LTO=full;
+    make clean;
     make test DCOMPILER=$DC DFLAGS=-static LDC_LTO=off;
   fi
 - if [[ "$LTO" == "runtime" && "$DC" == "ldc2" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,12 +92,10 @@ script:
     fi
   fi
 - if [[ "$DOCKERSPECIAL" == "1" ]]; then
-    docker run --rm -ti -v $(pwd):/src dlanguage/ldc make test DCOMPILER=$DC;
-    docker_status=$?;
-    echo $docker_status;
-    sudo chown -R $UID:$GID $(pwd);
-    make test-nobuild;
-    make clean;
+    docker run --rm -ti -v $(pwd):/src dlanguage/ldc make test DCOMPILER=$DC
+    && sudo chown -R $UID:$GID $(pwd)
+    && make test-nobuild
+    && make clean
   fi
 after_success:
 - if [[ "$CODECOV" == "1" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ script:
   fi
 - if [[ "$LTO" == "default" && "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" ]]; then
     make clean;
-    make test DCOMPILER=$DC DFLAGS=-static;
+    make test DCOMPILER=$DC;
+    make test DCOMPILER=$DC DFLAGS=-static LDC_LTO=off;
   fi
 - if [[ "$LTO" == "runtime" && "$DC" == "ldc2" ]]; then
     make clean;

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_deploy:
 - if [[ -z "$TRAVIS_TAG" || "$TRAVIS_TAG" == "" ]]; then export USE_VERSION="v~dev";
   else export USE_VERSION="$TRAVIS_TAG"; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" ]]; then export DFLAGS_STATIC=-static; fi
-- make package DCOMPILER=$DC OS=$TRAVIS_OS_NAME APP_VERSION=$USE_VERSION LDC_BUILD_RUNTIME=1 DFLAGS=$DFLAGS_STATIC
+- make package DCOMPILER=$DC OS=$TRAVIS_OS_NAME APP_VERSION=$USE_VERSION LDC_BUILD_RUNTIME=ldc-build-runtime DFLAGS=$DFLAGS_STATIC
 deploy:
   provider: releases
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@
 #   ALLLTO=[default|thin|full] - make test LDC_BUILD_RUNTIME=1 and LTO value
 #   DOCKERSPECIAL - Special dockerized build to run LDC with LTO and -static
 #   DEPLOY - Deploy if a tagged release.
-#       #docker run --rm -ti -v $(pwd):/src dlanguage/ldc make test DCOMPILER=$DC LDC_BUILD_RUNTIME=1 DFLAGS=-static;
 matrix:
   include:
     - os: osx
@@ -92,7 +91,7 @@ script:
     fi
   fi
 - if [[ "$DOCKERSPECIAL" == "1" ]]; then
-    docker run --rm -ti -v $(pwd):/src dlanguage/ldc make test DCOMPILER=$DC
+    docker run --rm -ti -v $(pwd):/src dlanguage/ldc make test DCOMPILER=$DC LDC_BUILD_RUNTIME=1 DFLAGS=-static;
     && sudo chown -R $UID:$GID $(pwd)
     && make test-nobuild
     && make clean;

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ script:
 - if [[ "$LTO" == "default" && "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" ]]; then
     make clean;
     make test DCOMPILER=$DC;
+    make test DCOMPILER=$DC LDC_LTO=full;
     make test DCOMPILER=$DC DFLAGS=-static LDC_LTO=off;
   fi
 - if [[ "$LTO" == "runtime" && "$DC" == "ldc2" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,14 @@ matrix:
       d: ldc
       services: docker
       env: DOCKERSPECIAL=1 DEPLOY=1
+    - os: linux
+      language: d
+      d: ldc
+      env: ALLLTO=thin
+    - os: linux
+      language: d
+      d: ldc
+      env: APPLTO=thin
 before_install:
   - if [[ "$DOCKERSPECIAL" == "1" ]]; then
       sudo apt-get -qq update
@@ -91,7 +99,7 @@ script:
     fi
   fi
 - if [[ "$DOCKERSPECIAL" == "1" ]]; then
-    docker run --rm -ti -v $(pwd):/src dlanguage/ldc make test DCOMPILER=$DC LDC_BUILD_RUNTIME=1 DFLAGS=-static
+    docker run --rm -ti -v $(pwd):/src dlanguage/ldc:1.5.0 make test DCOMPILER=ldc2 LDC_BUILD_RUNTIME=1 DFLAGS=-static
     && sudo chown -R $UID:$GID $(pwd)
     && make test-nobuild
     && make clean;

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ sudo: false
 os:
 - linux
 - osx
-osx_image: xcode8.2
+osx_image: xcode9
 language: d
 d:
-- ldc-1.2.0
+- ldc-1.5.0-beta1
 - dmd
 script:
 - dub run -- --compiler=$DC
@@ -14,6 +14,8 @@ script:
 - make clean
 - make test DCOMPILER=$DC
 - if [[ "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" ]]; then make clean; make test DCOMPILER=$DC DFLAGS=-static; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" ]]; then make clean; make test DCOMPILER=$DC LDC_BUILD_RUNTIME=1 DFLAGS=-static; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" && "$DC" == "ldc2" ]]; then make clean; make test DCOMPILER=$DC LDC_BUILD_RUNTIME=1; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" && "$DC" == "dmd" ]]; then make test-codecov; fi
 after_success:
 - if [[ "$TRAVIS_OS_NAME" == "osx" && "$DC" == "dmd" ]]; then bash <(curl -s https://codecov.io/bash)  ||
@@ -22,7 +24,7 @@ before_deploy:
 - if [[ -z "$TRAVIS_TAG" || "$TRAVIS_TAG" == "" ]]; then export USE_VERSION="v~dev";
   else export USE_VERSION="$TRAVIS_TAG"; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" ]]; then export DFLAGS_STATIC=-static; fi
-- make package DCOMPILER=$DC OS=$TRAVIS_OS_NAME APP_VERSION=$USE_VERSION DFLAGS=$DFLAGS_STATIC
+- make package DCOMPILER=$DC OS=$TRAVIS_OS_NAME APP_VERSION=$USE_VERSION LDC_BUILD_RUNTIME=1 DFLAGS=$DFLAGS_STATIC
 deploy:
   provider: releases
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,10 +85,11 @@ script:
 - if [[ ! -z "$ALLLTO" ]]; then
     if [[ "$ALLLTO" == "default" ]]; then
       make DCOMPILER=$DC LDC_RUNTIME_LTO=1;
+      make clean;
     else
       make DCOMPILER=$DC LDC_RUNTIME_LTO=1 LDC_LTO=$ALLLTO;
+      make clean;
     fi
-    make clean;
   fi
 - if [[ "$DOCKERSPECIAL" == "1" ]]; then
     docker run --rm -ti -v $(pwd):/src dlanguage/ldc make test DCOMPILER=$DC;

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@
 #   ALLLTO=[default|thin|full] - make test LDC_RUNTIME_LTO=1 and LTO value
 #   DOCKERSPECIAL - Special dockerized build to run LDC with LTO and -static
 #   DEPLOY - Deploy if a tagged release.
+#       #docker run --rm -ti -v $(pwd):/src dlanguage/ldc make test DCOMPILER=$DC LDC_RUNTIME_LTO=1 DFLAGS=-static;
 matrix:
   include:
     - os: osx
@@ -90,7 +91,6 @@ script:
     make clean;
   fi
 - if [[ "$DOCKERSPECIAL" == "1" ]]; then
-    #docker run --rm -ti -v $(pwd):/src dlanguage/ldc make test DCOMPILER=$DC LDC_RUNTIME_LTO=1 DFLAGS=-static;
     docker run --rm -ti -v $(pwd):/src dlanguage/ldc make test DCOMPILER=$DC;
     sudo chown -R $UID:$GID $(pwd);
     make test-nobuild;

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,26 +5,55 @@ os:
 osx_image: xcode9
 language: d
 d:
-- ldc-1.5.0-beta1
 - dmd
+- ldc-1.5.0-beta1
+env:
+- LTO=default
+- LTO=runtime
+matrix:
+  exclude:
+  - d: dmd
+    env: LTO=runtime
 script:
-- dub run -- --compiler=$DC
-- make test-nobuild
-- dub clean
-- make clean
-- make test DCOMPILER=$DC
-- if [[ "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" ]]; then make clean; make test DCOMPILER=$DC DFLAGS=-static; fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" ]]; then make clean; make test DCOMPILER=$DC LDC_BUILD_RUNTIME=ldc-build-runtime DFLAGS=-static; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" && "$DC" == "ldc2" ]]; then make clean; make test DCOMPILER=$DC LDC_BUILD_RUNTIME=ldc-build-runtime; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" && "$DC" == "dmd" ]]; then make test-codecov; fi
+- if [[ "$LTO" == "default" ]]; then
+    dub run -- --compiler=$DC;
+    make test-nobuild;
+    dub clean;
+    make clean;
+    make test DCOMPILER=$DC;
+  fi
+- if [[ "$LTO" == "default" &&  "$DC" == "dmd" && "$TRAVIS_OS_NAME" == "osx" ]]; then
+    make clean;
+    make test-codecov;
+  fi
+- if [[ "$LTO" == "default" && "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" && ]]; then
+    make clean;
+    make test DCOMPILER=$DC DFLAGS=-static;
+  fi
+- if [[ "$LTO" == "runtime" && "$DC" == "ldc2" && ]]; then
+    make clean;
+    make test DCOMPILER=$DC LDC_BUILD_RUNTIME=1;
+  fi
 after_success:
-- if [[ "$TRAVIS_OS_NAME" == "osx" && "$DC" == "dmd" ]]; then bash <(curl -s https://codecov.io/bash)  ||
-  echo "Codecov did not collect coverage reports"; fi
+- if [[ "$LTO" == "default" &&  "$DC" == "dmd" && "$TRAVIS_OS_NAME" == "osx" ]]; then
+    bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports";
+  fi
 before_deploy:
-- if [[ -z "$TRAVIS_TAG" || "$TRAVIS_TAG" == "" ]]; then export USE_VERSION="v~dev";
-  else export USE_VERSION="$TRAVIS_TAG"; fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" ]]; then export DFLAGS_STATIC=-static; fi
-- make package DCOMPILER=$DC OS=$TRAVIS_OS_NAME APP_VERSION=$USE_VERSION LDC_BUILD_RUNTIME=ldc-build-runtime DFLAGS=$DFLAGS_STATIC
+- if [[ -z "$TRAVIS_TAG" || "$TRAVIS_TAG" == "" ]]; then
+    export USE_VERSION="v~dev";
+  else
+    export USE_VERSION="$TRAVIS_TAG";
+  fi
+- if [[ "$LTO" == "runtime" ]]; then
+    export LDC_BUILD_RUNTIME_FLAG=1;
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      export OS_NAME_SUFFIX=-lto;
+    fi
+  elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    export DFLAGS_STATIC=-static;
+    export OS_NAME_SUFFIX=-staticlib;
+  fi
+- make package DCOMPILER=$DC OS=${TRAVIS_OS_NAME}${OS_NAME_SUFFIX} APP_VERSION=$USE_VERSION LDC_BUILD_RUNTIME=$LDC_BUILD_RUNTIME_FLAG DFLAGS=$DFLAGS_STATIC
 deploy:
   provider: releases
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,8 @@ script:
   fi
 - if [[ "$DOCKERSPECIAL" == "1" ]]; then
     docker run --rm -ti -v $(pwd):/src dlanguage/ldc make test DCOMPILER=$DC;
+    docker_status=$?;
+    echo $docker_status;
     sudo chown -R $UID:$GID $(pwd);
     make test-nobuild;
     make clean;

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
     - os: linux
       language: d
       d: ldc
-      env: ALLLTO=default
+      env: APPLTO=thin ALLLTO=default
     - os: linux
       dist: trusty
       sudo: required
@@ -51,14 +51,6 @@ matrix:
       d: ldc
       services: docker
       env: DOCKERSPECIAL=1 DEPLOY=1
-    - os: linux
-      language: d
-      d: ldc
-      env: ALLLTO=thin
-    - os: linux
-      language: d
-      d: ldc
-      env: APPLTO=thin
 before_install:
   - if [[ "$DOCKERSPECIAL" == "1" ]]; then
       sudo apt-get -qq update
@@ -86,7 +78,7 @@ script:
     make test-codecov;
   fi
 - if [[ ! -z "$APPLTO" ]]; then
-    make DCOMPILER=$DC LDC_LTO=$APPLTO
+    make test DCOMPILER=$DC LDC_LTO=$APPLTO
     && make clean;
   fi
 - if [[ ! -z "$ALLLTO" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,10 +70,10 @@ script:
 - if [[ "$MAKETEST" == "1" ]]; then
     make test DCOMPILER=$DC
     && make clean;
-    if [[ "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" ]]; then
-      make test DCOMPILER=$DC DFLAGS=-static
-      && make clean;
-    fi
+  fi
+- if [[ "$MAKETEST" == "1" && "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" ]]; then
+    make test DCOMPILER=$DC DFLAGS=-static
+    && make clean;
   fi
 - if [[ "$CODECOV" == "1" ]]; then
     make test-codecov;

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ script:
     docker run --rm -ti -v $(pwd):/src dlanguage/ldc make test DCOMPILER=$DC
     && sudo chown -R $UID:$GID $(pwd)
     && make test-nobuild
-    && make clean
+    && make clean;
   fi
 after_success:
 - if [[ "$CODECOV" == "1" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,11 @@ script:
     make clean;
     make test-codecov;
   fi
-- if [[ "$LTO" == "default" && "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" && ]]; then
+- if [[ "$LTO" == "default" && "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" ]]; then
     make clean;
     make test DCOMPILER=$DC DFLAGS=-static;
   fi
-- if [[ "$LTO" == "runtime" && "$DC" == "ldc2" && ]]; then
+- if [[ "$LTO" == "runtime" && "$DC" == "ldc2" ]]; then
     make clean;
     make test DCOMPILER=$DC LDC_BUILD_RUNTIME=1;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
     - os: linux
       language: d
       d: ldc-1.5.0
-      env: DUBTEST=1 MAKETEST=1 APPLTO=default
+      env: DUBTEST=1 MAKETEST=1 APPLTO=full
     - os: linux
       language: d
       d: ldc-1.5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,41 +54,41 @@ matrix:
       env: DOCKERSPECIAL=1 DEPLOY=1
 before_install:
   - if [[ "$DOCKERSPECIAL" == "1" ]]; then
-      sudo apt-get -qq update;
-      sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce;
-      docker pull dlanguage/ldc;
+      sudo apt-get -qq update
+      && sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+      && docker pull dlanguage/ldc;
       export UID=$(id -u);
       export GID=$(id -g);
     fi
 script:
 - if [[ "$DUBTEST" == "1" ]]; then
-    dub run -- --compiler=$DC;
-    make test-nobuild;
-    dub clean;
-    make clean;
+    dub run -- --compiler=$DC
+    && make test-nobuild
+    && dub clean
+    && make clean;
   fi
 - if [[ "$MAKETEST" == "1" ]]; then
-    make test DCOMPILER=$DC;
-    make clean;
+    make test DCOMPILER=$DC
+    && make clean;
     if [[ "$TRAVIS_OS_NAME" == "linux" && "$DC" == "ldc2" ]]; then
-      make test DCOMPILER=$DC DFLAGS=-static;
-      make clean;
+      make test DCOMPILER=$DC DFLAGS=-static
+      && make clean;
     fi
   fi
 - if [[ "$CODECOV" == "1" ]]; then
     make test-codecov;
   fi
 - if [[ ! -z "$APPLTO" ]]; then
-    make DCOMPILER=$DC LDC_LTO=$APPLTO;
-    make clean;
+    make DCOMPILER=$DC LDC_LTO=$APPLTO
+    && make clean;
   fi
 - if [[ ! -z "$ALLLTO" ]]; then
     if [[ "$ALLLTO" == "default" ]]; then
-      make test DCOMPILER=$DC LDC_BUILD_RUNTIME=1;
-      make clean;
+      make test DCOMPILER=$DC LDC_BUILD_RUNTIME=1
+      && make clean;
     else
-      make test DCOMPILER=$DC LDC_BUILD_RUNTIME=1 LDC_LTO=$ALLLTO;
-      make clean;
+      make test DCOMPILER=$DC LDC_BUILD_RUNTIME=1 LDC_LTO=$ALLLTO
+      && make clean;
     fi
   fi
 - if [[ "$DOCKERSPECIAL" == "1" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,33 +22,33 @@ matrix:
       language: d
       d: ldc-1.2.0
       env: DUBTEST=1 MAKETEST=1 APPLTO=off
-    - os: osx
-      osx_image: xcode9
-      language: d
-      d: ldc-1.5.0
-      env: DUBTEST=1 MAKETEST=1 APPLTO=off
-    - os: osx
-      osx_image: xcode9
-      language: d
-      d: ldc-1.5.0
-      env: ALLLTO=default DEPLOY=1
     - os: linux
       language: d
       d: ldc-1.2.0
       env: DUBTEST=1 MAKETEST=1
+    - os: osx
+      osx_image: xcode9
+      language: d
+      d: ldc
+      env: DUBTEST=1 MAKETEST=1 APPLTO=off
+    - os: osx
+      osx_image: xcode9
+      language: d
+      d: ldc
+      env: ALLLTO=default DEPLOY=1
     - os: linux
       language: d
-      d: ldc-1.5.0
+      d: ldc
       env: DUBTEST=1 MAKETEST=1 APPLTO=full
     - os: linux
       language: d
-      d: ldc-1.5.0
+      d: ldc
       env: ALLLTO=default
     - os: linux
       dist: trusty
       sudo: required
       language: d
-      d: ldc-1.5.0
+      d: ldc
       services: docker
       env: DOCKERSPECIAL=1 DEPLOY=1
 before_install:
@@ -91,7 +91,7 @@ script:
     fi
   fi
 - if [[ "$DOCKERSPECIAL" == "1" ]]; then
-    docker run --rm -ti -v $(pwd):/src dlanguage/ldc make test DCOMPILER=$DC LDC_BUILD_RUNTIME=1 DFLAGS=-static;
+    docker run --rm -ti -v $(pwd):/src dlanguage/ldc make test DCOMPILER=$DC LDC_BUILD_RUNTIME=1 DFLAGS=-static
     && sudo chown -R $UID:$GID $(pwd)
     && make test-nobuild
     && make clean;

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,10 +84,10 @@ script:
   fi
 - if [[ ! -z "$ALLLTO" ]]; then
     if [[ "$ALLLTO" == "default" ]]; then
-      make DCOMPILER=$DC LDC_BUILD_RUNTIME=1;
+      make test DCOMPILER=$DC LDC_BUILD_RUNTIME=1;
       make clean;
     else
-      make DCOMPILER=$DC LDC_BUILD_RUNTIME=1 LDC_LTO=$ALLLTO;
+      make test DCOMPILER=$DC LDC_BUILD_RUNTIME=1 LDC_LTO=$ALLLTO;
       make clean;
     fi
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@
 #   MAKETEST - make test, plus -static on LDC
 #   CODECOV - Runs code coverage
 #   APPLTO=[default|off|thin|full] - make test with the setting
-#   ALLLTO=[default|thin|full] - make test LDC_RUNTIME_LTO=1 and LTO value
+#   ALLLTO=[default|thin|full] - make test LDC_BUILD_RUNTIME=1 and LTO value
 #   DOCKERSPECIAL - Special dockerized build to run LDC with LTO and -static
 #   DEPLOY - Deploy if a tagged release.
-#       #docker run --rm -ti -v $(pwd):/src dlanguage/ldc make test DCOMPILER=$DC LDC_RUNTIME_LTO=1 DFLAGS=-static;
+#       #docker run --rm -ti -v $(pwd):/src dlanguage/ldc make test DCOMPILER=$DC LDC_BUILD_RUNTIME=1 DFLAGS=-static;
 matrix:
   include:
     - os: osx
@@ -84,10 +84,10 @@ script:
   fi
 - if [[ ! -z "$ALLLTO" ]]; then
     if [[ "$ALLLTO" == "default" ]]; then
-      make DCOMPILER=$DC LDC_RUNTIME_LTO=1;
+      make DCOMPILER=$DC LDC_BUILD_RUNTIME=1;
       make clean;
     else
-      make DCOMPILER=$DC LDC_RUNTIME_LTO=1 LDC_LTO=$ALLLTO;
+      make DCOMPILER=$DC LDC_BUILD_RUNTIME=1 LDC_LTO=$ALLLTO;
       make clean;
     fi
   fi
@@ -108,10 +108,10 @@ before_deploy:
     USE_VERSION="$TRAVIS_TAG";
   fi
 - if [[ "$DOCKERSPECIAL" == "1" ]]; then
-    docker run --rm -ti -v $(pwd):/src dlanguage/ldc make package DCOMPILER=$DC OS=$TRAVIS_OS_NAME APP_VERSION=$USE_VERSION LDC_RUNTIME_LTO=1 DFLAGS=-static;
+    docker run --rm -ti -v $(pwd):/src dlanguage/ldc make package DCOMPILER=$DC OS=$TRAVIS_OS_NAME APP_VERSION=$USE_VERSION LDC_BUILD_RUNTIME=1 DFLAGS=-static;
     sudo chown -R $UID:$GID $(pwd);
   else
-    make package DCOMPILER=$DC OS=$TRAVIS_OS_NAME APP_VERSION=$USE_VERSION LDC_RUNTIME_LTO=1;
+    make package DCOMPILER=$DC OS=$TRAVIS_OS_NAME APP_VERSION=$USE_VERSION LDC_BUILD_RUNTIME=1;
   fi
 deploy:
   provider: releases

--- a/buildtools/makefile
+++ b/buildtools/makefile
@@ -1,14 +1,28 @@
 DCOMPILER = dmd
 DFLAGS =
+DOCKER_LDC_IMAGE = dlanguage/ldc
 
-all: aggregate-codecov codecov-to-relative-paths
+all:  docker-ldc-wrappers aggregate-codecov codecov-to-relative-paths
 
-aggregate-codecov: aggregate-codecov.d
+aggregate-codecov: docker-ldc-wrappers aggregate-codecov.d
 	$(DCOMPILER) -release -O aggregate-codecov.d
 
-codecov-to-relative-paths: codecov-to-relative-paths.d
+codecov-to-relative-paths: docker-ldc-wrappers codecov-to-relative-paths.d
 	$(DCOMPILER) -release -O codecov-to-relative-paths.d
+
+docker-ldc-wrappers: docker-ldc2.sh docker-ldc-build-runtime.sh
+
+docker-ldc2.sh:
+	echo '#!/bin/sh\ndocker run --rm -ti -v $$(pwd):/src $(DOCKER_LDC_IMAGE) ldc2 $$*' > ./docker-ldc2.sh
+	chmod a+x docker-ldc2.sh
+
+docker-ldc-build-runtime.sh:
+	echo '#!/bin/sh\ndocker run --rm -ti -v $$(pwd):/src $(DOCKER_LDC_IMAGE) ldc-build-runtime $$*' > docker-ldc-build-runtime.sh
+	chmod a+x docker-ldc-build-runtime.sh
 
 clean:
 	-rm aggregate-codecov
+	-rm codecov-to-relative-paths
 	-rm *.o
+	-rm docker-ldc2.sh
+	-rm docker-ldc-build-runtime.sh

--- a/common/src/tsvutils_version.d
+++ b/common/src/tsvutils_version.d
@@ -1,4 +1,4 @@
-enum string tsvutilsVersion = "v1.1.14";
+enum string tsvutilsVersion = "v1.1.15-dev";
 
 string tsvutilsVersionNotice (string toolName)
 {

--- a/makeapp.mk
+++ b/makeapp.mk
@@ -12,11 +12,11 @@ release: $(app_release)
 debug: $(app_debug)
 codecov: $(app_codecov)
 
-$(app_release): $(srcs)
+$(app_release): ldc-build-runtime-libs $(srcs)
 	$(DCOMPILER) $(release_flags) -of$(app_release) $(imports) $(srcs)
-$(app_debug): $(srcs)
+$(app_debug):  ldc-build-runtime-libs $(srcs)
 	$(DCOMPILER) $(debug_flags) -of$(app_debug) $(imports) $(srcs)
-$(app_codecov): $(srcs)
+$(app_codecov): ldc-build-runtime-libs $(srcs)
 	$(DCOMPILER) $(codecov_flags) -of$(app_codecov) $(imports) $(srcs)
 
 clean:
@@ -99,6 +99,14 @@ apptest-codecov: $(app_codecov)
 	else echo '---> $(app) command line tests failed (code coverage on).'; \
 	exit 1; \
 	fi
+
+.PHONY: ldc-build-runtime-libs
+ldc-build-runtime-libs: $(ldc_build_runtime_dir)
+
+$(ldc_build_runtime_dir):
+ifdef LDC_BUILD_RUNTIME
+	$(ldc_build_runtime_tool) --dFlags="$(ldc_build_runtime_dflags)" --buildDir $(ldc_build_runtime_dir) BUILD_SHARED_LIBS=OFF
+endif
 
 buildtools:
 	@echo ''

--- a/makedefs.mk
+++ b/makedefs.mk
@@ -181,7 +181,7 @@ ifeq ($(compiler_type),ldc)
 	endif
 
 	ifeq ($(OS_NAME),Darwin)
-		ldc_build_runtime_dflags = -flto=$(LDC_LTO);-ar=
+		ldc_build_runtime_dflags = -flto=$(LDC_LTO)
 	else
 		ldc_build_runtime_dflags = -flto=$(LDC_LTO)
 	endif
@@ -190,11 +190,11 @@ ifeq ($(compiler_type),ldc)
 		ifeq ($(OS_NAME),Darwin)
 			lto_link_flags = -L-L$(ldc_build_runtime_dir)/lib
 		else
-			lto_link_flags = -L-L$(ldc_build_runtime_dir)/lib -Xcc=-fuse-ld=gold
+			lto_link_flags = -L-L$(ldc_build_runtime_dir)/lib -linker=gold
 		endif
 	else ifneq ($(LDC_LTO),off)
 		ifneq ($(OS_NAME),Darwin)
-			lto_link_flags = -Xcc=-fuse-ld=gold
+			lto_link_flags = -linker=gold
 		endif
 	endif
 endif

--- a/makedefs.mk
+++ b/makedefs.mk
@@ -5,34 +5,137 @@
 # examples. The 'common' subdirectory makefile also includes this, but has it's own
 # makefile targets.
 #
-# This makefile can be customized by setting the DCOMPILER and DFLAGS variable. These
-# can also be set on the make command line.
+# This makefile can be customized by setting the DCOMPILER, DFLAGS, LDC_LTO, and
+# LDC_RUNTIME_LTO variables. These can also be set on the make command line.
+#
+# - DCOMPILER - path to the D compiler to use. Should include one of 'dmd', 'ldc', or
+#   'gdc' in the compiler name.
+# - DFLAGS are passed to the compiler on the command line.
+# - LDC_LTO should be either 'thin' or 'full'. It is only used if DCOMPILER specifies an
+#   ldc compiler. It overrides the default LTO setting.
+# - LDC_BUILD_RUNTIME - Used to enable building the druntime and phobos runtime libraries
+#   using LTO. If set to '1', builds the runtimes using the 'ldc-build-runtime' tool.
+#   Otherwise is expected to be a path to the tool. Available starting with ldc 1.5.
 
-DCOMPILER = dmd
+
+DCOMPILER =
 DFLAGS =
+LDC_LTO =
+LDC_BUILD_RUNTIME =
 
 project_dir ?= $(realpath ..)
 common_srcdir = $(project_dir)/common/src
 project_bindir = $(project_dir)/bin
 buildtools_dir = $(project_dir)/buildtools
+ldc_runtime_thin_dir = $(project_dir)/ldc-build-runtime.thin
+ldc_runtime_full_dir = $(project_dir)/ldc-build-runtime.full
+# Thin vs Full build dir set later in file
+ldc_build_runtime_dir =
 objdir = obj
 bindir = bin
 testsdir = tests
 
 OS_NAME := $(shell uname -s)
 
-FLTO_OPTION =
-ifeq ($(OS_NAME),Darwin)
-	FLTO_OPTION = -flto=thin
+# Identify the compiler
+
+dmd_compiler =
+ldc_compiler =
+gdc_compiler =
+
+ifndef DCOMPILER
+	DCOMPILER = dmd
+	dmd_compiler = 1
+else
+	compiler_name = $(notdir $(basename $(DCOMPILER)))
+
+	ifeq ($(compiler_name),dmd)
+		dmd_compiler = 1
+	else ifeq ($(compiler_name),ldc)
+		ldc_compiler = 1
+	else ifeq ($(compiler_name),ldc2)
+		ldc_compiler = 1
+	else ifeq ($(compiler_name),gdc)
+		gdc_compiler = 1
+	else ifeq ($(compiler_name),ldc)
+		ldc_compiler = 1
+	else ifeq ($(findstring dmd,$(compiler_name)),dmd)
+		dmd_compiler = 1
+	else ifeq ($(findstring ldc,$(compiler_name)),ldc)
+		ldc_compiler = 1
+	else ifeq ($(findstring gdc,$(compiler_name)),gdc)
+		gcd_compiler = 1
+	else
+		dmd_compiler = 1
+	endif
 endif
 
-release_flags_base = -release -O3 -boundscheck=off -singleobj $(FLTO_OPTION)
-ifeq ($(notdir $(basename $(DCOMPILER))),dmd)
+ldc_build_runtime_tool_name = ldc-build-runtime
+ldc_build_runtime_tool = $(ldc_build_runtime_tool_name)
+ifdef LDC_BUILD_RUNTIME
+	ifneq ($(LDC_BUILD_RUNTIME),1)
+		ldc_build_runtime_tool=$(LDC_BUILD_RUNTIME)
+	else
+		ldc_bin_dir = $(dir $(realpath $(DCOMPILER)))
+		ifdef ldc_bin_dir
+			ldc_build_runtime_tool = $(ldc_bin_dir)/$(ldc_build_runtime_tool_name)
+		endif
+	endif
+	ifndef LDC_LTO
+		LDC_LTO = thin
+	endif
+endif
+
+ifdef LDC_LTO
+	ifeq ($(LDC_LTO),thin)
+		ldc_build_runtime_dir = $(ldc_runtime_thin_dir)
+	else ifeq ($(LDC_LTO),full)
+		ldc_build_runtime_dir = $(ldc_runtime_full_dir)
+	else
+		$(error "Invalid LDC_LTO value: $(LDC_LTO). Must be either 'thin' or 'full'")
+	endif
+endif
+
+ldc_build_runtime_dflags =
+lto_option =
+lto_release_option =
+
+ifdef ldc_compiler
+	ifdef LDC_LTO
+		lto_option = -flto=$(LDC_LTO)
+		lto_release_option = -flto=$(LDC_LTO)
+	else ifeq ($(OS_NAME),Darwin)
+		LDC_LTO = thin
+		lto_release_option = -flto=$(LDC_LTO)
+	endif
+
+	ifeq ($(OS_NAME),Darwin)
+		ldc_build_runtime_dflags = -flto=$(LDC_LTO);-ar=
+	else
+		ldc_build_runtime_dflags = -flto=$(LDC_LTO)
+	endif
+endif
+
+debug_flags_base =
+release_flags_base = -release -O
+link_flags_base =
+
+ifdef dmd_compiler
 	release_flags_base = -release -O -boundscheck=off -inline
+else ifdef ldc_compiler
+	debug_flags_base = $(lto_option)
+	release_flags_base = -release -O3 -boundscheck=off -singleobj $(lto_release_option)
+	ifdef LDC_BUILD_RUNTIME
+		ifeq ($(OS_NAME),Darwin)
+			link_flags_base = -L-L$(ldc_build_runtime_dir)/lib
+		else
+			link_flags_base = -L-L$(ldc_build_runtime_dir)/lib -Xcc=-fuse-ld=gold
+		endif
+	endif
 endif
 
-debug_flags = -od$(objdir) $(DFLAGS)
-release_flags = $(release_flags_base) -od$(objdir) $(DFLAGS)
+debug_flags = $(debug_flags_base) -od$(objdir) $(link_flags_base) $(DFLAGS)
+release_flags = $(release_flags_base) -od$(objdir) $(link_flags_base) $(DFLAGS)
 unittest_flags = $(DFLAGS) -unittest -main -run
 codecov_flags = -od$(objdir) $(DFLAGS) -cov
 unittest_codecov_flags = -od$(objdir) $(DFLAGS) -cov -unittest -main -run

--- a/makedefs.mk
+++ b/makedefs.mk
@@ -130,6 +130,10 @@ else ifdef ldc_compiler
 		else
 			link_flags_base = -L-L$(ldc_build_runtime_dir)/lib -Xcc=-fuse-ld=gold
 		endif
+	else ifdef LDC_LTO
+		ifneq ($(OS_NAME),Darwin)
+			link_flags_base = -Xcc=-fuse-ld=gold
+		endif
 	endif
 endif
 

--- a/makedefs.mk
+++ b/makedefs.mk
@@ -75,11 +75,6 @@ ldc_build_runtime_tool = $(ldc_build_runtime_tool_name)
 ifdef LDC_BUILD_RUNTIME
 	ifneq ($(LDC_BUILD_RUNTIME),1)
 		ldc_build_runtime_tool=$(LDC_BUILD_RUNTIME)
-	else
-		ldc_bin_dir = $(dir $(realpath $(DCOMPILER)))
-		ifdef ldc_bin_dir
-			ldc_build_runtime_tool = $(ldc_bin_dir)/$(ldc_build_runtime_tool_name)
-		endif
 	endif
 	ifndef LDC_LTO
 		ifeq ($(OS_NAME),Darwin)

--- a/makedefs.mk
+++ b/makedefs.mk
@@ -151,7 +151,7 @@ ifeq ($(compiler_type),ldc)
 		ifeq ($(OS_NAME),Darwin)
 			override LDC_LTO = thin
 		else
-			override LDC_LTO = full
+			override LDC_LTO = off
 		endif
 	endif
 

--- a/makedefs.mk
+++ b/makedefs.mk
@@ -10,18 +10,28 @@
 #
 # - DCOMPILER - path to the D compiler to use. Should include one of 'dmd', 'ldc', or
 #   'gdc' in the compiler name.
-# - DFLAGS are passed to the compiler on the command line.
-# - LDC_LTO should be either 'thin' or 'full'. It is only used if DCOMPILER specifies an
-#   ldc compiler. It overrides the default LTO setting.
+# - DFLAGS - Passed to the compiler on the command line.
+# - LDC_LTO - One of 'thin', 'full', 'off', or 'default'. An empty or undefined value
+#   is treated as 'default'. It is only used if DCOMPILER specifies an ldc compiler.
 # - LDC_BUILD_RUNTIME - Used to enable building the druntime and phobos runtime libraries
 #   using LTO. If set to '1', builds the runtimes using the 'ldc-build-runtime' tool.
 #   Otherwise is expected to be a path to the tool. Available starting with ldc 1.5.
-
+#
+# Current LTO defaults when using LDC:
+# - OS X: thin
+# - OS X, LDC_BUILD_RUNTIME: thin
+# - Linux: off
+# - Linux, LDC_BUILD_RUNTIME: full
+#
+# NOTE: Due to https://github.com/ldc-developers/ldc/issues/2208, LTO is only
+# on OS X in release mode. Issue seen in LDC 1.5.0-beta1 with tsv-filter.
 
 DCOMPILER =
 DFLAGS =
 LDC_LTO =
 LDC_BUILD_RUNTIME =
+
+## Directory paths
 
 project_dir ?= $(realpath ..)
 common_srcdir = $(project_dir)/common/src
@@ -29,82 +39,144 @@ project_bindir = $(project_dir)/bin
 buildtools_dir = $(project_dir)/buildtools
 ldc_runtime_thin_dir = $(project_dir)/ldc-build-runtime.thin
 ldc_runtime_full_dir = $(project_dir)/ldc-build-runtime.full
-# Thin vs Full build dir set later in file
-ldc_build_runtime_dir =
 objdir = obj
 bindir = bin
 testsdir = tests
 
 OS_NAME := $(shell uname -s)
 
-# Identify the compiler
+## Identify the compiler as dmd, ldc, or gdc
 
-dmd_compiler =
-ldc_compiler =
-gdc_compiler =
+compiler_type =
 
 ifndef DCOMPILER
 	DCOMPILER = dmd
-	dmd_compiler = 1
+	compiler_type = dmd
 else
 	compiler_name = $(notdir $(basename $(DCOMPILER)))
 
 	ifeq ($(compiler_name),dmd)
-		dmd_compiler = 1
+		compiler_type = dmd
 	else ifeq ($(compiler_name),ldc)
-		ldc_compiler = 1
+		compiler_type = ldc
 	else ifeq ($(compiler_name),ldc2)
-		ldc_compiler = 1
+		compiler_type = ldc
 	else ifeq ($(compiler_name),gdc)
-		gdc_compiler = 1
-	else ifeq ($(compiler_name),ldc)
-		ldc_compiler = 1
+		compiler_type = gdc
 	else ifeq ($(findstring dmd,$(compiler_name)),dmd)
-		dmd_compiler = 1
+		compiler_type = dmd
 	else ifeq ($(findstring ldc,$(compiler_name)),ldc)
-		ldc_compiler = 1
+		compiler_type = ldc
 	else ifeq ($(findstring gdc,$(compiler_name)),gdc)
-		gcd_compiler = 1
+		compiler_type = gdc
 	else
-		dmd_compiler = 1
+		compiler_type = dmd
 	endif
 endif
 
-ldc_build_runtime_tool_name = ldc-build-runtime
-ldc_build_runtime_tool = $(ldc_build_runtime_tool_name)
-ifdef LDC_BUILD_RUNTIME
-	ifneq ($(LDC_BUILD_RUNTIME),1)
-		ldc_build_runtime_tool=$(LDC_BUILD_RUNTIME)
-	endif
-	ifndef LDC_LTO
-		ifeq ($(OS_NAME),Darwin)
-			LDC_LTO = thin
-		else
-			LDC_LTO = full
+## Make sure compiler_type was set to something legitimate.
+ifneq ($(compiler_type),dmd)
+	ifneq ($(compiler_type),ldc)
+		ifneq ($(compiler_type),gdc)
+			$(error "Internal error. Invalid compiler_type value: '$(compiler_type)'. Must be 'dmd', 'ldc', or 'gdc'.")
 		endif
 	endif
 endif
 
-ifdef LDC_LTO
+ifneq ($(compiler_type),ldc)
+	ifneq ($(LDC_LTO),)
+		$(warning "Non-LDC compiler detected ($(compiler_type)). Ignoring LDC_LTO parameter: '$(LDC_LTO)'.")
+	endif
+	ifneq ($(LDC_BUILD_RUNTIME),)
+		$(warning "Non-LDC compiler detected ($(compiler_type)). Ignoring LDC_BUILD_RUNTIME parameter: '$(LDC_BUILD_RUNTIME)'.")
+	endif
+endif
+
+## Variables used for LDC LTO. These get updated when using the LDC compiler
+##   ldc_build_runtime_tool - Path to the ldc-build-runtime tool
+##   ldc_build_runtime_dir - Directory for the runtime (ldc-build-runtime.[thin|full])
+##   ldc_build_runtime_dflags = Flags passed to ldc-build-runtime tool. eg. -flto=[thin|full]
+##   lto_option - LTO option passed to ldc (-flto=[thin|full).
+##   lto_release_option - LTO option passed to ldc (-flto=[thin|full) on release builds.
+##   lto_link_flags - Additional linker flags to pass to compiler
+
+ldc_build_runtime_tool =
+ldc_build_runtime_dir = ldc-build-runtime.off
+ldc_build_runtime_dflags =
+lto_option =
+lto_release_option =
+lto_link_flags =
+
+## If using LDC, setup all the parameters
+
+ifeq ($(compiler_type),ldc)
+	# Update/validate the LDC_LTO parameter
+	ifeq ($(LDC_LTO),)
+		override LDC_LTO = default
+	endif
+
+	ifneq ($(LDC_LTO),default)
+		ifneq ($(LDC_LTO),thin)
+			ifneq ($(LDC_LTO),full)
+				ifneq ($(LDC_LTO),off)
+					$(error "Invalid LDC_LTO value: '$(LDC_LTO)'. Must be 'thin', 'full', 'off', 'default', or empty.")
+				endif
+			endif
+		endif
+	endif
+
+	ifneq ($(LDC_BUILD_RUNTIME),)
+		ifeq ($(LDC_LTO),off)
+			$(error "LDC_LTO value 'off' inconsistent with LDC_BUILD_RUNTIME value '$(LDC_BUILD_RUNTIME)'")
+		endif
+	endif
+
+	# Set the ldc-build-tool path and select the LDC_LTO default
+
+	ldc_build_runtime_tool_name = ldc-build-runtime
+	ldc_build_runtime_tool = $(ldc_build_runtime_tool_name)
+
+	ifneq ($(LDC_BUILD_RUNTIME),)
+		ifneq ($(LDC_BUILD_RUNTIME),1)
+			ldc_build_runtime_tool=$(LDC_BUILD_RUNTIME)
+		endif
+		ifeq ($(LDC_LTO),default)
+			ifeq ($(OS_NAME),Darwin)
+				override LDC_LTO = thin
+			else
+				override LDC_LTO = full
+			endif
+		endif
+	else ifeq ($(LDC_LTO),default)
+		ifeq ($(OS_NAME),Darwin)
+			override LDC_LTO = thin
+		else
+			override LDC_LTO = full
+		endif
+	endif
+
+	# Ensure LDC_LTO is set correctly. Either thin, full, or off at this point.
+
+	ifneq ($(LDC_LTO),thin)
+		ifneq ($(LDC_LTO),full)
+			ifneq ($(LDC_LTO),off)
+				$(error "Internal error. Invalid LDC_LTO value: '$(LDC_LTO)'. Must be 'thin', 'full', or 'off' at this line.")
+			endif
+		endif
+	endif
+
+	# Update the ldc_build_runtime_dir name.
+
 	ifeq ($(LDC_LTO),thin)
 		ldc_build_runtime_dir = $(ldc_runtime_thin_dir)
 	else ifeq ($(LDC_LTO),full)
 		ldc_build_runtime_dir = $(ldc_runtime_full_dir)
-	else
-		$(error "Invalid LDC_LTO value: $(LDC_LTO). Must be either 'thin' or 'full'")
 	endif
-endif
 
-ldc_build_runtime_dflags =
-lto_option =
-lto_release_option =
+	# Set the LTO compile/link options
 
-ifdef ldc_compiler
-	ifdef LDC_LTO
+	ifneq ($(LDC_LTO),off)
 		lto_option = -flto=$(LDC_LTO)
-		lto_release_option = -flto=$(LDC_LTO)
-	else ifeq ($(OS_NAME),Darwin)
-		LDC_LTO = thin
 		lto_release_option = -flto=$(LDC_LTO)
 	endif
 
@@ -113,32 +185,42 @@ ifdef ldc_compiler
 	else
 		ldc_build_runtime_dflags = -flto=$(LDC_LTO)
 	endif
-endif
 
-debug_flags_base =
-release_flags_base = -release -O
-link_flags_base =
-
-ifdef dmd_compiler
-	release_flags_base = -release -O -boundscheck=off -inline
-else ifdef ldc_compiler
-	debug_flags_base = $(lto_option)
-	release_flags_base = -release -O3 -boundscheck=off -singleobj $(lto_release_option)
-	ifdef LDC_BUILD_RUNTIME
+	ifneq ($(LDC_BUILD_RUNTIME),)
 		ifeq ($(OS_NAME),Darwin)
-			link_flags_base = -L-L$(ldc_build_runtime_dir)/lib
+			lto_link_flags = -L-L$(ldc_build_runtime_dir)/lib
 		else
-			link_flags_base = -L-L$(ldc_build_runtime_dir)/lib -Xcc=-fuse-ld=gold
+			lto_link_flags = -L-L$(ldc_build_runtime_dir)/lib -Xcc=-fuse-ld=gold
 		endif
-	else ifdef LDC_LTO
+	else ifneq ($(LDC_LTO),off)
 		ifneq ($(OS_NAME),Darwin)
 			link_flags_base = -Xcc=-fuse-ld=gold
 		endif
 	endif
 endif
 
-debug_flags = $(debug_flags_base) -od$(objdir) $(link_flags_base) $(DFLAGS)
-release_flags = $(release_flags_base) -od$(objdir) $(link_flags_base) $(DFLAGS)
+## Done with the LDC LTO setting. Now the general compile/link settings.
+
+debug_compile_flags_base =
+release_compile_flags_base = -release -O
+debug_link_flags_base =
+release_link_flags_base =
+
+ifeq ($(compiler_type),dmd)
+	release_compile_flags_base = -release -O -boundscheck=off -inline
+else ifeq ($(compiler_type),ldc)
+	# NOTE: Due to https://github.com/ldc-developers/ldc/issues/2208, only
+	# use LTO on OS X in release mode. Issue seen in LDC 1.5.0-beta1 with tsv-filter.
+	ifneq ($(OS_NAME),Darwin)
+		debug_compile_flags_base = $(lto_option)
+		debug_link_flags_base = $(lto_link_flags)
+	endif
+	release_compile_flags_base = -release -O3 -boundscheck=off -singleobj $(lto_release_option)
+	release_link_flags_base = $(lto_link_flags)
+endif
+
+debug_flags = $(debug_compile_flags_base) -od$(objdir) $(debug_link_flags_base) $(DFLAGS)
+release_flags = $(release_compile_flags_base) -od$(objdir) $(release_link_flags_base) $(DFLAGS)
 unittest_flags = $(DFLAGS) -unittest -main -run
 codecov_flags = -od$(objdir) $(DFLAGS) -cov
 unittest_codecov_flags = -od$(objdir) $(DFLAGS) -cov -unittest -main -run

--- a/makedefs.mk
+++ b/makedefs.mk
@@ -194,7 +194,7 @@ ifeq ($(compiler_type),ldc)
 		endif
 	else ifneq ($(LDC_LTO),off)
 		ifneq ($(OS_NAME),Darwin)
-			link_flags_base = -Xcc=-fuse-ld=gold
+			lto_link_flags = -Xcc=-fuse-ld=gold
 		endif
 	endif
 endif

--- a/makedefs.mk
+++ b/makedefs.mk
@@ -82,7 +82,11 @@ ifdef LDC_BUILD_RUNTIME
 		endif
 	endif
 	ifndef LDC_LTO
-		LDC_LTO = thin
+		ifeq ($(OS_NAME),Darwin)
+			LDC_LTO = thin
+		else
+			LDC_LTO = full
+		endif
 	endif
 endif
 

--- a/makedefs.mk
+++ b/makedefs.mk
@@ -6,7 +6,7 @@
 # makefile targets.
 #
 # This makefile can be customized by setting the DCOMPILER, DFLAGS, LDC_LTO, and
-# LDC_RUNTIME_LTO variables. These can also be set on the make command line.
+# LDC_BUILD_RUNTIME variables. These can also be set on the make command line.
 #
 # - DCOMPILER - path to the D compiler to use. Should include one of 'dmd', 'ldc', or
 #   'gdc' in the compiler name.

--- a/makefile
+++ b/makefile
@@ -32,8 +32,18 @@ help:
 	@echo 'unittest-codecov - Runs unit tests with code coverage reports on.'
 	@echo 'package      - Creates a release package. Used with travis-ci.'
 	@echo ''
-	@echo 'Note: Commands that run builds use the DMD compiler by default.'
-	@echo '      Add DCOMPILER=ldc2 or DCOMPILER=<path> to change the compiler.'
+	@echo 'Note: DMD is the default compiler. Use the DCOMPILER parameter to switch. For example:'
+	@echo ''
+	@echo '    $$ make DCOMPILER=ldc2'
+	@echo ''
+	@echo 'Parameters:'
+	@echo '==========='
+	@echo 'DCOMPILER - Compiler to use. Defaults to DMD. Value can be a path.'
+	@echo 'DFLAGS - Extra flags to pass to the compiler.'
+	@echo 'LDC_BUILD_RUNTIME - Enables LDC support for using LTO on the runtime libraries. Use'
+	@echo '    the value 1 to turn on. The value can also be a path to the ldc-build-runtime tool.'
+	@echo 'LDC_LTO - Controls the LDC LTO options. See makedefs.mk for details.'
+	@echo ''
 
 release: make_subdirs
 debug: make_subdirs

--- a/makefile
+++ b/makefile
@@ -7,7 +7,8 @@ OS ?= UnkOS
 ARCH ?= x86_64
 APP_VERSION ?= v~dev
 PKG_ROOT_DIR ?= $(notdir $(basename $(CURDIR)))
-PKG_DIR = $(PKG_ROOT_DIR)-$(APP_VERSION)_$(OS)-$(ARCH)_$(DCOMPILER)
+DCOMPILER_BASENAME = $(notdir $(basename $(DCOMPILER)))
+PKG_DIR = $(PKG_ROOT_DIR)-$(APP_VERSION)_$(OS)-$(ARCH)_$(DCOMPILER_BASENAME)
 TAR_FILE ?= $(PKG_DIR).tar.gz
 
 all: release


### PR DESCRIPTION
This PR adds support for LDC 1.5.0 photos/druntime LTO capabilities to the makefiles. Tests and package builds were added to travis-ci continuous builds.

By default, runtime LTO is turned off in the makefiles. This is to reduce problems that may be encountered in different system environments. Runtime LTO support can be added by setting the make argument `LDC_BUILD_RUNTIME=1`. Support has not been added to the `dub` build system.

Travis builds are setup to build release packages using runtime LTO.

Makefiles and the travis build was significantly overhauled to create this support. It is now easier to engage the different LTO options when using make.