### PR TITLE
Add link to AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,12 @@ There are several ways to obtain the tools: prebuilt binaries; building from sou
 
 Prebuilt binaries are available for Linux and Mac, these can be found on the [Github releases](https://github.com/eBay/tsv-utils-dlang/releases) page. Download and unpack the tar.gz file. Executables are in the `bin` directory. Add the `bin` directory or individual tools to the `PATH` environment variable.
 
+For some distributions, a package can directly be installed:
+
+| Distribution | Command               |
+| ------------ | --------------------- |
+| Arch Linux   | `pacaur -S tsv-utils` (see [`tsv-utils`](https://aur.archlinux.org/packages/tsv-utils/))
+
 ### Build from source files
 
 [Download a D compiler](https://dlang.org/download.html). These tools have been tested with the DMD and LDC compilers, on Mac OSX and Linux. Use DMD version 2.070 or later, LDC version 1.0.0 or later.


### PR DESCRIPTION
Hi Jon,

As I use your great tools from time to time, I added an ArchLinux AUR package for it. That's the community-maintained package build repository for ArchLinux.
As ArchLinux seems to be quite popular in the D community, this might also be interesting to others.
I wasn't sure what t

See also: https://aur.archlinux.org/packages/tsv-utils