### PR TITLE
Buffered output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,13 @@ matrix:
       language: d
       d: ldc-1.2.0
       env: DUBTEST=1 MAKETEST=1
-      if: fork = false
+      if: fork = true
     - os: osx
       osx_image: xcode9
       language: d
       d: ldc
       env: DUBTEST=1 MAKETEST=1 APPLTO=off
-      if: fork = false
+      if: fork = true
 #    - os: osx
 #      osx_image: xcode9
 #      language: d
@@ -48,12 +48,12 @@ matrix:
       language: d
       d: ldc
       env: DUBTEST=1 MAKETEST=1 APPLTO=full
-      if: fork = false
+      if: fork = true
     - os: linux
       language: d
       d: ldc
       env: APPLTO=thin ALLLTO=default
-      if: fork = false
+      if: fork = true
     - os: linux
       language: d
       d: ldc

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,13 @@ matrix:
       language: d
       d: ldc-1.2.0
       env: DUBTEST=1 MAKETEST=1
+      if: NOT fork
     - os: osx
       osx_image: xcode9
       language: d
       d: ldc
       env: DUBTEST=1 MAKETEST=1 APPLTO=off
+      if: NOT fork
 #    - os: osx
 #      osx_image: xcode9
 #      language: d
@@ -46,10 +48,12 @@ matrix:
       language: d
       d: ldc
       env: DUBTEST=1 MAKETEST=1 APPLTO=full
+      if: NOT fork
     - os: linux
       language: d
       d: ldc
       env: APPLTO=thin ALLLTO=default
+      if: NOT fork
     - os: linux
       language: d
       d: ldc

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,13 @@ matrix:
       language: d
       d: ldc-1.2.0
       env: DUBTEST=1 MAKETEST=1
-      if: NOT fork
+      if: fork = false
     - os: osx
       osx_image: xcode9
       language: d
       d: ldc
       env: DUBTEST=1 MAKETEST=1 APPLTO=off
-      if: NOT fork
+      if: fork = false
 #    - os: osx
 #      osx_image: xcode9
 #      language: d
@@ -48,12 +48,12 @@ matrix:
       language: d
       d: ldc
       env: DUBTEST=1 MAKETEST=1 APPLTO=full
-      if: NOT fork
+      if: fork = false
     - os: linux
       language: d
       d: ldc
       env: APPLTO=thin ALLLTO=default
-      if: NOT fork
+      if: fork = false
     - os: linux
       language: d
       d: ldc

--- a/common/README.md
+++ b/common/README.md
@@ -4,6 +4,8 @@ _Visit the eBay TSV utilities [main page](../README.md)_
 
 This directory contains utility functions shared by multiple TSV utility tools. A few that may be of more general interest:
 * **InputFieldReordering** - A class that creates a reordered subset of fields from an input line. Used to operate on a subset of fields in the order specified on the command line. *File: tsvutils.d*.
+* **BufferedOutputRange** - An OutputRange with an internal buffer used to buffer output.
+  Intended for use with stdout, it is a significant performance benefit. *File: tsvutils.d*.
 * **quantile** - Calculates a cummulative probability for values in a data set. Supports the same interpolation methods as the quantile function in R and many other statistical packages. *File: tsv_numerics.d*.
 * **rangeMedian** - Finds the median in a range. Implements via the faster of `std.algorithm.topN` or `std.algorithm.sort` depending on the Phobos version. *File: tsv_numerics.d*.
 * **formatNumber** - An alternate print format for numbers, especially useful when doubles are being used to represent integer and float values. *File: tsv_numerics.d*.

--- a/common/makefile
+++ b/common/makefile
@@ -1,5 +1,8 @@
 include ../makedefs.mk
 
+unittest_utils_srcs ?= $(CURDIR)/src/unittest_utils.d
+imports ?= -I$(CURDIR)/src
+
 release: ;
 debug: ;
 codecov: ;
@@ -19,10 +22,10 @@ test: unittest
 .PHONY: unittest
 unittest:
 	@echo '---> Running $(notdir $(basename $(CURDIR))) unit tests'
-	$(DCOMPILER) $(common_srcs) $(unittest_flags) $(CURDIR)/src/tsvutil.d
-	$(DCOMPILER) $(common_srcs) $(unittest_flags) $(CURDIR)/src/getopt_inorder.d
-	$(DCOMPILER) $(common_srcs) $(unittest_flags) $(CURDIR)/src/tsv_numerics.d
-	$(DCOMPILER) $(common_srcs) $(unittest_flags) $(CURDIR)/src/tsvutils_version.d
+	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_flags) $(CURDIR)/src/tsvutil.d
+	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_flags) $(CURDIR)/src/getopt_inorder.d
+	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_flags) $(CURDIR)/src/tsv_numerics.d
+	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_flags) $(CURDIR)/src/tsvutils_version.d
 	@echo '---> Unit tests completed successfully.'
 
 test-debug: ;
@@ -36,9 +39,10 @@ test-codecov: unittest-codecov
 unittest-codecov:
 	@echo '---> Running $(notdir $(basename $(CURDIR))) unit tests with code coverage.'
 	-rm ./*.lst
-	$(DCOMPILER) $(common_srcs) $(unittest_codecov_flags) $(CURDIR)/src/tsvutil.d
-	$(DCOMPILER) $(common_srcs) $(unittest_codecov_flags) $(CURDIR)/src/getopt_inorder.d
-	$(DCOMPILER) $(common_srcs) $(unittest_codecov_flags) $(CURDIR)/src/tsv_numerics.d
+	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(CURDIR)/src/tsvutil.d
+	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(CURDIR)/src/getopt_inorder.d
+	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(CURDIR)/src/tsv_numerics.d
+	$(DCOMPILER) $(imports) $(unittest_utils_srcs) $(unittest_codecov_flags) $(CURDIR)/src/tsvutils_version.d
 	-rm ./__main.lst
 	@echo '---> Unit tests completed successfully (code coverage on).'
 

--- a/common/src/tsvutil.d
+++ b/common/src/tsvutil.d
@@ -489,9 +489,10 @@ unittest
     }
     assert(filepath2.readText == "file2: abcdefghijkl100\n0 1 2 3 4 5 6 7 8 9\n");
 
-    /* With a locking text writer. */
-
-    version(none)
+    /* With a locking text writer. Requires version 2.078.0
+       See: https://issues.dlang.org/show_bug.cgi?id=9661
+     */
+    static if (__VERSION__ >= 2078)
     {
         string filepath3 = buildPath(testDir, "file3.txt");
         {
@@ -503,9 +504,9 @@ unittest
                 ostream.append("file3: ");
                 ostream.append("abc");
                 ostream.append(["def", "ghi", "jkl"]);
-            ostream.appendln("100");
-            ostream.append(iota(0, 10).map!(x => x.to!string).joiner(" "));
-            ostream.appendln();
+                ostream.appendln("100");
+                ostream.append(iota(0, 10).map!(x => x.to!string).joiner(" "));
+                ostream.appendln();
             }
         }
         assert(filepath3.readText == "file3: abcdefghijkl100\n0 1 2 3 4 5 6 7 8 9\n");

--- a/common/src/tsvutil.d
+++ b/common/src/tsvutil.d
@@ -2,10 +2,13 @@
 Utilities used by TSV applications.
 
 Utilities in this file:
-* InputFieldReordering class - A class that creates a reordered subset of fields from an
+* InputFieldReordering - A class that creates a reordered subset of fields from an
   input line. Fields in the subset are accessed by array indicies. This is especially
   useful when processing the subset in a specific order, such as the order listed on the
   command-line at run-time.
+
+* BufferedOutputRange - An OutputRange with an internal buffer used to buffer output.
+  Intended for use with stdout, it is a significant performance benefit.
 
 * joinAppend - A function that performs a join, but appending the join output to an
   output stream. It is a performance improvement over using join or joiner with writeln.
@@ -13,8 +16,11 @@ Utilities in this file:
 * getTsvFieldValue - A convenience function when only a single value is needed from an
   input line.
 
-* parseFieldList, makeFieldListOptionHandler - Helper functions for parsing field-lists
-  entered on the command line.
+* Field-lists: parseFieldList, makeFieldListOptionHandler - Helper functions for parsing
+  field-lists entered on the command line.
+
+* throwIfWindowsNewlineOnUnix - A utility for Unix platform builds to detecting Windows
+  newlines in input.
 
 Copyright (c) 2015-2018, eBay Software Foundation
 Initially written by Jon Degenhardt
@@ -32,7 +38,8 @@ import std.typecons : Flag, No, Yes;
 alias EnablePartialLines = Flag!"enablePartialLines";
 
 /**
-Move select fields from an input line to an output array, reordering along the way.
+InputFieldReordering - Move select fields from an input line to an output array,
+reordering along the way.
 
 The InputFieldReordering class is used to reorder a subset of fields from an input line.
 The caller instantiates an InputFieldReordering object at the start of input processing.
@@ -349,14 +356,39 @@ unittest
 }
 
 /**
-BufferedOutput
- */
+BufferedOutputRange is a performance enhancement over writing directly to an output
+stream. It holds a File or OutputRange. Output is held in an internal buffer prior an
+written to the File or OutputRange as a block.
+
+BufferedOutputRange was designed specifically for writing to stdout, but it can write
+to either a File open for writing or an OutputRange. It is often dramatically faster
+than writing to stdout directly. This is especially noticable for outputs with short
+lines, as it blocks many writes together in a single write.
+
+BufferedOutputRange has a number of its own methods. It also exposes a put method so
+it can be used as an OutputRange.
+
+* this(outputStream [, flushSize, reserveSize]) - Constructor
+* append(stuff) - Append to the internal buffer. This will not flush to the output stream.
+* appendln(stuff) - Append to the internal buffer, followed by a newline. The buffer is
+      flushed to the output stream if is has reached flushSize.
+* appendln() - Append a newline to the internal buffer. The buffer is flushed to the output
+      stream if is has reached flushSize.
+* joinAppend(inputRange, delim) - An optimization of append(inputRange.joiner(delim).
+      For reasons that are not clear, joiner is quite slow.
+* flushIfFull() - Flush the internal buffer to the output stream if it has reached flushSize.
+* flush() - Write the internal buffer to the output stream.
+* put(stuff) - To act as an OutputRange. Appends to the internal buffer. Acts as appendln()
+      if passed a single newline character ('\n' or "\n").
+
+The internal buffer is automatically flushed when the BufferedOutputRange goes out of scope.
+*/
 
 import std.stdio : isFileHandle;
 import std.range : isOutputRange;
 import std.traits : Unqual;
 
-struct BufferedOutput(OutputTarget)
+struct BufferedOutputRange(OutputTarget)
     if (isFileHandle!(Unqual!OutputTarget) || isOutputRange!(Unqual!OutputTarget, char))
 {
     import std.range : isOutputRange;
@@ -426,6 +458,26 @@ struct BufferedOutput(OutputTarget)
         appendln();
     }
 
+    /* joinAppend is an optimization of append(inputRange.joiner(delimiter).
+     * This form is quite a bit faster, 40%+ on some benchmarks.
+     */
+    void joinAppend(InputRange, E)(InputRange inputRange, E delimiter)
+        if (isInputRange!InputRange &&
+            is(ElementType!InputRange : const C[]) &&
+            (is(E : const C[]) || is(E : const C)))
+    {
+        if (!inputRange.empty)
+        {
+            append(inputRange.front);
+            inputRange.popFront;
+        }
+        foreach (x; inputRange)
+        {
+            append(delimiter);
+            append(x);
+        }
+    }
+
     /* Make this an output range. */
     void put(T)(T stuff)
     {
@@ -464,7 +516,7 @@ unittest
     {
         import std.stdio : File;
 
-        auto ostream = BufferedOutput!File(filepath1.File("w"));
+        auto ostream = BufferedOutputRange!File(filepath1.File("w"));
         ostream.append("file1: ");
         ostream.append("abc");
         ostream.append(["def", "ghi", "jkl"]);
@@ -479,7 +531,7 @@ unittest
     {
         import std.stdio : File;
 
-        auto ostream = BufferedOutput!File(filepath2.File("w"), 0, 0);
+        auto ostream = BufferedOutputRange!File(filepath2.File("w"), 0, 0);
         ostream.append("file2: ");
         ostream.append("abc");
         ostream.append(["def", "ghi", "jkl"]);
@@ -500,7 +552,7 @@ unittest
 
             auto ltw = filepath3.File("w").lockingTextWriter;
             {
-                auto ostream = BufferedOutput!(typeof(ltw))(ltw);
+                auto ostream = BufferedOutputRange!(typeof(ltw))(ltw);
                 ostream.append("file3: ");
                 ostream.append("abc");
                 ostream.append(["def", "ghi", "jkl"]);
@@ -516,7 +568,7 @@ unittest
     import std.array : appender;
     auto app1 = appender!(char[]);
     {
-        auto ostream = BufferedOutput!(typeof(app1))(app1);
+        auto ostream = BufferedOutputRange!(typeof(app1))(app1);
         ostream.append("appender1: ");
         ostream.append("abc");
         ostream.append(["def", "ghi", "jkl"]);
@@ -529,7 +581,7 @@ unittest
     /* With an Appender, but checking flush boundaries. */
     auto app2 = appender!(char[]);
     {
-        auto ostream = BufferedOutput!(typeof(app2))(app2, 10, 0); // Flush if 10+
+        auto ostream = BufferedOutputRange!(typeof(app2))(app2, 10, 0); // Flush if 10+
         assert(app2.data == "");
         ostream.append("12345678"); // Not flushed yet.
         assert(app2.data == "");
@@ -555,36 +607,53 @@ unittest
     }
     assert(app2.data == "123456789012345");
 
+    /* Using joinAppend. */
+    auto app1b = appender!(char[]);
+    {
+        auto ostream = BufferedOutputRange!(typeof(app1b))(app1b);
+        ostream.append("appenderB: ");
+        ostream.joinAppend(["a", "bc", "def"], '-');
+        ostream.append(':');
+        ostream.joinAppend(["g", "hi", "jkl"], '-');
+        ostream.appendln("*100*");
+        ostream.joinAppend(iota(0, 6).map!(x => x.to!string), ' ');
+        ostream.append(' ');
+        ostream.joinAppend(iota(6, 10).map!(x => x.to!string), " ");
+        ostream.appendln();
+    }
+    assert(app1b.data == "appenderB: a-bc-def:g-hi-jkl*100*\n0 1 2 3 4 5 6 7 8 9\n",
+           "app1b.data: |" ~app1b.data ~ "|");
+
     /* Operating as an output range. When passed to a function as a ref, exiting
      * the function does not flush. When passed as a value, it get flushed when
-     * the function returns.
+     * the function returns. Also test both UCFS and non-UFCS styles.
      */
 
     void outputStuffAsRef(T)(ref T range)
         if (isOutputRange!(T, char))
     {
         range.put('1');
-        range.put("23");
+        put(range, "23");
         range.put('\n');
         range.put(["5", "67"]);
-        range.put(iota(8, 10).map!(x => x.to!string));
-        range.put("\n");
+        put(range, iota(8, 10).map!(x => x.to!string));
+        put(range, "\n");
     }
 
     void outputStuffAsVal(T)(T range)
         if (isOutputRange!(T, char))
     {
-        range.put('1');
+        put(range, '1');
         range.put("23");
-        range.put('\n');
-        range.put(["5", "67"]);
+        put(range, '\n');
+        put(range, ["5", "67"]);
         range.put(iota(8, 10).map!(x => x.to!string));
         range.put("\n");
     }
 
     auto app3 = appender!(char[]);
     {
-        auto ostream = BufferedOutput!(typeof(app3))(app3, 12, 0);
+        auto ostream = BufferedOutputRange!(typeof(app3))(app3, 12, 0);
         outputStuffAsRef(ostream);
         assert(app3.data == "", "app3.data: |" ~app3.data ~ "|");
         outputStuffAsRef(ostream);
@@ -594,7 +663,7 @@ unittest
 
     auto app4 = appender!(char[]);
     {
-        auto ostream = BufferedOutput!(typeof(app4))(app4, 12, 0);
+        auto ostream = BufferedOutputRange!(typeof(app4))(app4, 12, 0);
         outputStuffAsVal(ostream);
         assert(app4.data == "123\n56789\n", "app4.data: |" ~app4.data ~ "|");
         outputStuffAsVal(ostream);
@@ -607,7 +676,10 @@ unittest
 joinAppend performs a join operation on an input range, appending the results to
 an output range.
 
-This routine was written as a performance enhancement over using std.algorithm.joiner
+Note: The main uses of joinAppend have been replaced by BufferedOutputRange, which has
+its own joinAppend method.
+
+joinAppend was written as a performance enhancement over using std.algorithm.joiner
 or std.array.join with writeln. Using joiner with writeln is quite slow, 3-4x slower
 than std.array.join with writeln. The joiner performance may be due to interaction
 with writeln, this was not investigated. Using joiner with stdout.lockingTextWriter
@@ -617,8 +689,8 @@ but is allocating memory unnecessarily.
 Using joinAppend with Appender is a bit faster than join, and allocates less memory.
 The Appender re-uses the underlying data buffer, saving memory. The example below
 illustrates. It is a modification of the InputFieldReordering example. The role
-Appender plus joinAppend are playing is to buffer the output. This can also be used to
-buffer multiple lines, improving performance further.
+Appender plus joinAppend are playing is to buffer the output. BufferedOutputRange
+uses a similar technique to buffer multiple lines.
 
     int main(string[] args)
     {
@@ -848,7 +920,7 @@ unittest
 }
 
 /**
-Fieldlists - A field-list is a string entered on the command line identifying one or more
+Field-lists - A field-list is a string entered on the command line identifying one or more
 field numbers. They are used by the majority of the tsv utility applications. There are
 two helper functions, makeFieldListOptionHandler and parseFieldList. Most applications
 will use makeFieldListOptionHandler, it creates a delegate that can be passed to

--- a/csv2tsv/tests/gold/error_tests_1.txt
+++ b/csv2tsv/tests/gold/error_tests_1.txt
@@ -21,11 +21,11 @@ Error [csv2tsv]: Cannot open file `nosuchfile.txt' in mode `rb' (No such file or
 Error [csv2tsv]: Invalid CSV. Improperly terminated quoted field. File: invalid1.csv, Line: 3
 field1	field2	field3
 100	ab c	de f
-
+200	gh i,
 
 ====[csv2tsv invalid2.csv]====
 Error [csv2tsv]: Invalid CSV. Improperly terminated quoted field. File: invalid2.csv, Line: 4
 field1	field2	field3
 100	ab c	de f
 200	gh i	jk l
-
+300	mn o	pq r 

--- a/number-lines/src/number-lines.d
+++ b/number-lines/src/number-lines.d
@@ -122,26 +122,34 @@ int main(string[] cmdArgs)
 
 void numberLines(in NumberLinesOptions cmdopt, in string[] inputFiles)
 {
+    import std.conv : to;
     import std.range;
+    import tsvutil : BufferedOutputRange;
+
+    auto bufferedOutput = BufferedOutputRange!(typeof(stdout))(stdout);
 
     long lineNum = cmdopt.startNum;
     bool headerWritten = false;
     foreach (filename; (inputFiles.length > 0) ? inputFiles : ["-"])
     {
         auto inputStream = (filename == "-") ? stdin : filename.File();
-        foreach (fileLineNum, line; inputStream.byLine(KeepTerminator.yes).enumerate(1))
+        foreach (fileLineNum, line; inputStream.byLine(KeepTerminator.no).enumerate(1))
         {
             if (cmdopt.hasHeader && fileLineNum == 1)
             {
                 if (!headerWritten)
                 {
-                    write(cmdopt.headerString, cmdopt.delim, line);
+                    bufferedOutput.append(cmdopt.headerString);
+                    bufferedOutput.append(cmdopt.delim);
+                    bufferedOutput.appendln(line);
                     headerWritten = true;
                 }
             }
             else
             {
-                write(lineNum, cmdopt.delim, line);
+                bufferedOutput.append(lineNum.to!string);
+                bufferedOutput.append(cmdopt.delim);
+                bufferedOutput.appendln(line);
                 lineNum++;
             }
         }

--- a/tsv-append/src/tsv-append.d
+++ b/tsv-append/src/tsv-append.d
@@ -22,6 +22,7 @@ else
 {
     int main(string[] cmdArgs)
     {
+        import tsvutil : BufferedOutputRange;
         /* When running in DMD code coverage mode, turn on report merging. */
         version(D_Coverage) version(DigitalMars)
         {
@@ -32,7 +33,7 @@ else
         TsvAppendOptions cmdopt;
         auto r = cmdopt.processArgs(cmdArgs);
         if (!r[0]) return r[1];
-        try tsvAppend(cmdopt, stdout.lockingTextWriter);
+        try tsvAppend(cmdopt, BufferedOutputRange!(typeof(stdout))(stdout));
         catch (Exception exc)
         {
             stderr.writefln("Error [%s]: %s", cmdopt.programName, exc.msg);
@@ -203,7 +204,7 @@ void tsvAppend(OutputRange)(TsvAppendOptions cmdopt, OutputRange outputStream)
     {
         auto inputStream = (filename == "-") ? stdin : filename.File();
         auto sourceName = cmdopt.fileSourceNames[filename];
-        foreach (fileLineNum, line; inputStream.byLine(KeepTerminator.yes).enumerate(1))
+        foreach (fileLineNum, line; inputStream.byLine(KeepTerminator.no).enumerate(1))
         {
             if (cmdopt.hasHeader && fileLineNum == 1)
             {
@@ -215,6 +216,7 @@ void tsvAppend(OutputRange)(TsvAppendOptions cmdopt, OutputRange outputStream)
                         outputStream.put(cmdopt.delim);
                     }
                     outputStream.put(line);
+                    outputStream.put('\n');
                     headerWritten = true;
                 }
             }
@@ -226,6 +228,7 @@ void tsvAppend(OutputRange)(TsvAppendOptions cmdopt, OutputRange outputStream)
                     outputStream.put(cmdopt.delim);
                 }
                 outputStream.put(line);
+                outputStream.put('\n');
             }
         }
     }

--- a/tsv-sample/src/tsv-sample.d
+++ b/tsv-sample/src/tsv-sample.d
@@ -33,21 +33,24 @@ else
         if (!r[0]) return r[1];
         try
         {
+            import tsvutil : BufferedOutputRange;
+            auto bufferedOutput = BufferedOutputRange!(typeof(stdout))(stdout);
+
             if (cmdopt.useStreamSampling)
             {
-                streamSampling(cmdopt, stdout.lockingTextWriter);
+                streamSampling(cmdopt, bufferedOutput);
             }
             else if (cmdopt.useDistinctSampling)
             {
-                distinctSampling(cmdopt, stdout.lockingTextWriter);
+                distinctSampling(cmdopt, bufferedOutput);
             }
             else if (cmdopt.sampleSize == 0)
             {
-                reservoirSampling!(Yes.permuteAll)(cmdopt, stdout.lockingTextWriter);
+                reservoirSampling!(Yes.permuteAll)(cmdopt, bufferedOutput);
             }
             else
             {
-                reservoirSampling!(No.permuteAll)(cmdopt, stdout.lockingTextWriter);
+                reservoirSampling!(No.permuteAll)(cmdopt, bufferedOutput);
             }
         }
         catch (Exception exc)


### PR DESCRIPTION
Added a BufferedOutputRange intended as a way to buffer output being sent to `stdout`. It also has mechanisms to avoid `std.algorithm.joiner` performance issues. This can substantially improve performance, especially when writing short lines. A number of tools were updated to use it, though not all.