### PR TITLE
Build system updates; Prep for LDC IR-PGO

### DIFF
--- a/csv2tsv/profile_data/collect_profile_data.sh
+++ b/csv2tsv/profile_data/collect_profile_data.sh
@@ -8,6 +8,13 @@ fi
 prog=$1
 shift
 
+ldc_profdata_tool_name=ldc-profdata
+ldc_profdata_tool=${ldc_profdata_tool_name}
+
+if [ $# -ne 0 ]; then
+   ldc_profdata_tool=${1}/bin/${ldc_profdata_tool_name}
+fi
+
 for f in profile.*.raw; do
     if [ -e $f ]; then
         rm $f
@@ -24,4 +31,4 @@ $prog profile_data_3a.csv > /dev/null
 $prog profile_data_3b.csv > /dev/null
 $prog profile_data_5.csv > /dev/null
 
-ldc-profdata merge -o app.profdata profile.*.raw
+${ldc_profdata_tool} merge -o app.profdata profile.*.raw

--- a/makeapp.mk
+++ b/makeapp.mk
@@ -127,7 +127,7 @@ $(ldc_profdata_file):
 	$(DCOMPILER) $(release_instrumented_flags) -of$(app_instrumented) $(imports) $(srcs)
 	@echo ''
 	@echo '---> PGO: Collecting profile data'
-	cd $(ldc_profile_data_dir) && ./$(ldc_profdata_collect_prog) $(app_instrumented)
+	cd $(ldc_profile_data_dir) && ./$(ldc_profdata_collect_prog) $(app_instrumented) $(LDC_HOME)
 	@echo '---> PGO: Collection complete'
 	@echo ''
 

--- a/makeapp.mk
+++ b/makeapp.mk
@@ -56,6 +56,7 @@ test-debug: $(app_debug)
 	@if diff -q $(testsdir)/latest_debug $(testsdir)/gold ; \
 	then echo '---> $(app) command line tests passed.'; exit 0; \
 	else echo '---> $(app) command line tests failed.'; \
+	diff $(testsdir)/latest_debug $(testsdir)/gold | head -n 40; \
 	exit 1; \
 	fi
 
@@ -67,6 +68,7 @@ test-release: $(app_release)
 	@if diff -q $(testsdir)/latest_release $(testsdir)/gold ; \
 	then echo '---> $(app) command line tests passed.'; exit 0; \
 	else echo '---> $(app) command line tests failed.'; \
+	diff $(testsdir)/latest_release $(testsdir)/gold | head -n 40; \
 	exit 1; \
 	fi
 
@@ -78,6 +80,7 @@ test-nobuild:
 	@if diff -q $(testsdir)/latest_release $(testsdir)/gold ; \
 	then echo '---> $(app) command line tests passed.'; exit 0; \
 	else echo '---> $(app) command line tests failed.'; \
+	diff $(testsdir)/latest_release $(testsdir)/gold | head -n 40; \
 	exit 1; \
 	fi
 
@@ -109,6 +112,7 @@ apptest-codecov: $(app_codecov)
 	@if diff -q $(testsdir)/latest_debug $(testsdir)/gold ; \
 	then echo '---> $(app) command line tests passed (code coverage on).'; exit 0; \
 	else echo '---> $(app) command line tests failed (code coverage on).'; \
+	diff $(testsdir)/latest_debug $(testsdir)/gold | head -n 40; \
 	exit 1; \
 	fi
 

--- a/makefile
+++ b/makefile
@@ -54,7 +54,8 @@ help:
 	@echo '    showing the largest performance benefits. If LDC_PGO=2, PGO is used on all apps it'
 	@echo '    has been enabled for. Speed gains are smaller for the additional apps. PGO has'
 	@echo '    longer build times. LDC_PGO=1 is a good compromise between build time and performance.'
-	@echo "LDC_PGO_TYPE - Either 'IR' or 'AST'. Defaults to AST.'
+	@echo "LDC_PGO_TYPE - Either 'IR' or 'AST'. Defaults to AST. Currently only AST is supported.'
+	@echo "    IR-PGO is anticipated in a future LDC release.
 	@echo ''
 
 release: make_subdirs

--- a/makefile
+++ b/makefile
@@ -43,14 +43,18 @@ help:
 	@echo '==========='
 	@echo 'DCOMPILER - Compiler to use. Defaults to DMD. Value can be a path.'
 	@echo 'DFLAGS - Extra flags to pass to the compiler.'
+	@echo 'LDC_HOME - The LDC install directory. If provided, all LDC binaries will located in'
+	@echo '    in the bin directory inside LDC_HOME.'
 	@echo 'LDC_BUILD_RUNTIME - Enables LDC support for using LTO on the runtime libraries. Use'
-	@echo '    the value 1 to turn on. The value can also be a path to the ldc-build-runtime tool.'
-	@echo 'LDC_LTO - Controls the LDC LTO options. See makedefs.mk for details.'
+	@echo '    the value 1 to turn on.'
+	@echo "LDC_LTO - LDC LTO options. One of 'thin', 'full', 'off', or 'default'. Leave unspecified"
+	@echo '    to use the default (recommended).'
 	@echo 'LDC_PGO - Turns on Profile Guided Optimization. This is available for a subset of apps,'
 	@echo '    release builds with LDC_BUILD_RUNTIME=1 only. If LDC_PGO=1, PGO is used on the apps'
 	@echo '    showing the largest performance benefits. If LDC_PGO=2, PGO is used on all apps it'
 	@echo '    has been enabled for. Speed gains are smaller for the additional apps. PGO has'
 	@echo '    longer build times. LDC_PGO=1 is a good compromise between build time and performance.'
+	@echo "LDC_PGO_TYPE - Either 'IR' or 'AST'. Defaults to AST.'
 	@echo ''
 
 release: make_subdirs

--- a/tsv-filter/profile_data/collect_profile_data.sh
+++ b/tsv-filter/profile_data/collect_profile_data.sh
@@ -8,6 +8,13 @@ fi
 prog=$1
 shift
 
+ldc_profdata_tool_name=ldc-profdata
+ldc_profdata_tool=${ldc_profdata_tool_name}
+
+if [ $# -ne 0 ]; then
+   ldc_profdata_tool=${1}/bin/${ldc_profdata_tool_name}
+fi
+
 for f in profile.*.raw; do
     if [ -e $f ]; then
         rm $f
@@ -81,4 +88,4 @@ $prog profile_data_4.tsv -H --is-numeric 3 > /dev/null
 $prog profile_data_4.tsv -H --is-nan 3 > /dev/null
 $prog profile_data_4.tsv -H --is-finite 3 --le 3:30 > /dev/null
 
-ldc-profdata merge -o app.profdata profile.*.raw
+${ldc_profdata_tool} merge -o app.profdata profile.*.raw

--- a/tsv-sample/profile_data/collect_profile_data.sh
+++ b/tsv-sample/profile_data/collect_profile_data.sh
@@ -8,6 +8,13 @@ fi
 prog=$1
 shift
 
+ldc_profdata_tool_name=ldc-profdata
+ldc_profdata_tool=${ldc_profdata_tool_name}
+
+if [ $# -ne 0 ]; then
+   ldc_profdata_tool=${1}/bin/${ldc_profdata_tool_name}
+fi
+
 for f in profile.*.raw; do
     if [ -e $f ]; then
         rm $f
@@ -45,4 +52,4 @@ $prog profile_data_3.tsv -H -k 1,3 -r 0.20 > /dev/null
 $prog profile_data_3.tsv -H -k 1 -r 0.25 > /dev/null
 $prog profile_data_3.tsv -H -w 2 > /dev/null
 
-ldc-profdata merge -o app.profdata profile.*.raw
+${ldc_profdata_tool} merge -o app.profdata profile.*.raw

--- a/tsv-select/profile_data/collect_profile_data.sh
+++ b/tsv-select/profile_data/collect_profile_data.sh
@@ -8,6 +8,13 @@ fi
 prog=$1
 shift
 
+ldc_profdata_tool_name=ldc-profdata
+ldc_profdata_tool=${ldc_profdata_tool_name}
+
+if [ $# -ne 0 ]; then
+   ldc_profdata_tool=${1}/bin/${ldc_profdata_tool_name}
+fi
+
 for f in profile.*.raw; do
     if [ -e $f ]; then
         rm $f
@@ -31,4 +38,4 @@ $prog profile_data_3.tsv -H -f 1-3 > /dev/null
 $prog profile_data_3.tsv -H -f 7 > /dev/null
 $prog profile_data_3.tsv -H -f 3-6 > /dev/null
 
-ldc-profdata merge -o app.profdata profile.*.raw
+${ldc_profdata_tool} merge -o app.profdata profile.*.raw

--- a/tsv-summarize/profile_data/collect_profile_data.sh
+++ b/tsv-summarize/profile_data/collect_profile_data.sh
@@ -8,6 +8,13 @@ fi
 prog=$1
 shift
 
+ldc_profdata_tool_name=ldc-profdata
+ldc_profdata_tool=${ldc_profdata_tool_name}
+
+if [ $# -ne 0 ]; then
+   ldc_profdata_tool=${1}/bin/${ldc_profdata_tool_name}
+fi
+
 for f in profile.*.raw; do
     if [ -e $f ]; then
         rm $f
@@ -26,4 +33,4 @@ $prog profile_data_3.tsv -H --unique-count 1,3 --missing-count 5 --not-missing-c
 $prog profile_data_3.tsv -H --group-by 1,3 --count --range 6-8 --median 6-8 > /dev/null
 $prog profile_data_3.tsv -H --group-by 1 --count --retain 2 --first 6 --last 7 --mode 5 --mode-count 5 --values 3 > /dev/null
 
-ldc-profdata merge -o app.profdata profile.*.raw
+${ldc_profdata_tool} merge -o app.profdata profile.*.raw


### PR DESCRIPTION
Several build system improvements. These are motivated by the upcoming LDC IR-PGO support expected in LDC 1.8.0:
- Separate ldc-build-runtime directories for each compiler version
- Specify ldc home directory on make line. Helps when testing multiple compilers, as there are multiple tools in the LDC directory that need to be invoked.
- Specify a way to engage IR-LDC on the make line. Invokes compilation/link as currently defined. (Note: Doesn't work properly yet with LTO.)
- Output diff context on command line test failure. Should make it easier to diagnose problems encountered on TravisCI builds.