### PR TITLE
tsv-filter: disable PGO on OS X (LDC issue #2585).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,13 @@ matrix:
 #      language: d
 #      d: ldc
 #      env: DUBTEST=1 MAKETEST=1 APPLTO=off
+#      if: type IN (pull_request, cron)
 #      if: fork = true
-#    - os: osx
-#      osx_image: xcode9
-#      language: d
-#      d: ldc
-#      env: LTOPGO=default
+    - os: osx
+      osx_image: xcode9
+      language: d
+      d: ldc
+      env: LTOPGO=default
     - os: osx
       osx_image: xcode9
       language: d

--- a/tsv-filter/makefile
+++ b/tsv-filter/makefile
@@ -1,4 +1,9 @@
-APP_USES_LDC_PGO=2
+# tsv-filter should be able to use PGO, but a bug causes problems on OS X
+# LDC Issue 2585: https://github.com/ldc-developers/ldc/issues/2585
+ifneq ($(shell uname -s),Darwin)
+	APP_USES_LDC_PGO=2
+endif
+
 include ../makedefs.mk
 include ../makeapp.mk
 


### PR DESCRIPTION
`tsv-filter` does not work correctly when built with LTO and PGO on OS X with LDC 1.8.0 (https://github.com/ldc-developers/ldc/issues/2585). This disables PGO for `tsv-filter` on OS X. PGO can be re-enabled after a fix is found.