### PR TITLE
tsv-filter: fix xcode 9.3 & LDC w/ LTO builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
 #      if: type IN (pull_request, cron)
 #      if: fork = true
     - os: osx
-      osx_image: xcode9
+      osx_image: xcode9.3
       language: d
       d: ldc
       env: LTOPGO=default

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
 #      if: type IN (pull_request, cron)
 #      if: fork = true
     - os: osx
-      osx_image: xcode9.3
+      osx_image: xcode9.3beta
       language: d
       d: ldc
       env: LTOPGO=default

--- a/tsv-filter/makefile
+++ b/tsv-filter/makefile
@@ -1,10 +1,18 @@
-# tsv-filter should be able to use PGO, but a bug causes problems on OS X
-# LDC Issue 2585: https://github.com/ldc-developers/ldc/issues/2585
-ifneq ($(shell uname -s),Darwin)
-	APP_USES_LDC_PGO=2
-endif
+APP_USES_LDC_PGO=2
 
 include ../makedefs.mk
+
+# tsv-filter has issues with LTO on OS X with xcode 9.3, LDC2 1.8.0.
+# LDC Issue 2585: https://github.com/ldc-developers/ldc/issues/2585
+# Issues go beyond issue 2585 discussion. With xcode 9.3 all LTO fails.
+# Fix by adding -disable-fp-elim to release_flags created by makedefs.mk.
+
+ifeq ($(shell uname -s),Darwin)
+	ifeq ($(compiler_type),ldc)
+		override release_flags += -disable-fp-elim
+	endif
+endif
+
 include ../makeapp.mk
 
 # No built-in unit tests


### PR DESCRIPTION
There are issues with xcode 9.3 (OS X) and LDC 1.8.0 using LTO (full or thin). It requires using compiler option `-disable-fp-elim`, see [LDC Issue 2585](https://github.com/ldc-developers/ldc/issues/2585).

This fixes it and sets up a travis build that tests it.